### PR TITLE
execute the dnsimp test in the right directory

### DIFF
--- a/TESTS/Makefile.am
+++ b/TESTS/Makefile.am
@@ -3,7 +3,7 @@ LDADD=$(top_builddir)/libarpack.la $(BLAS_LIBS) $(LAPACK_LIBS)
 AM_DEFAULT_SOURCE_EXT = .f
 
 check_PROGRAMS = dnsimp bug_1315_single bug_1315_double bug_1323
-TESTS = $(check_PROGRAMS)
+TESTS = test-dnsimp.sh bug_1315_single bug_1315_double bug_1323
 
 EXTRA_DIST = testA.mtx
 

--- a/TESTS/Makefile.am
+++ b/TESTS/Makefile.am
@@ -5,7 +5,7 @@ AM_DEFAULT_SOURCE_EXT = .f
 check_PROGRAMS = dnsimp bug_1315_single bug_1315_double bug_1323
 TESTS = test-dnsimp.sh bug_1315_single bug_1315_double bug_1323
 
-EXTRA_DIST = testA.mtx
+EXTRA_DIST = testA.mtx test-dnsimp.sh
 
 dnsimp_SOURCES = dnsimp.f mmio.f debug.h
 

--- a/TESTS/test-dnsimp.sh
+++ b/TESTS/test-dnsimp.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+pwd=$(pwd)
+cd "$srcdir" && exec "$pwd/dnsimp"


### PR DESCRIPTION
Fixes opencollab/arpack-ng#14