### PR TITLE
rename pdlamch to pdlamch10 to avoid symbol collision with Scalapack …

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
 arpack-ng - 3.3.0
+ [ Denis Davydov ]
+ * Rename pdlamch to pdlamch10 to avoid symbol collision with Scalapack 2.0.2 in MPI context.
 
  [ Kyle Guinn ]
  * General improvements on the build system

--- a/PARPACK/SRC/MPI/Makefile.am
+++ b/PARPACK/SRC/MPI/Makefile.am
@@ -20,7 +20,7 @@ EXTRA_DIST = debug.h stat.h
 
 noinst_LTLIBRARIES = libparpack_noopt.la libparpacksrcmpi.la
 
-libparpack_noopt_la_SOURCES = pslamch.f pdlamch.f
+libparpack_noopt_la_SOURCES = pslamch.f pdlamch10.f
 libparpack_noopt_la_FFLAGS = -O0
 
 libparpacksrcmpi_la_SOURCES = $(SSRC) $(DSRC) $(CSRC) $(ZSRC)

--- a/PARPACK/SRC/MPI/pdlamch10.f
+++ b/PARPACK/SRC/MPI/pdlamch10.f
@@ -1,10 +1,14 @@
-      DOUBLE PRECISION   FUNCTION PDLAMCH( ICTXT, CMACH )
+      DOUBLE PRECISION   FUNCTION PDLAMCH10( ICTXT, CMACH )
       include "mpif.h"
 *
 *  -- ScaLAPACK auxilliary routine (version 1.0) --
 *     University of Tennessee, Knoxville, Oak Ridge National Laboratory,
 *     and University of California, Berkeley.
 *     February 28, 1995
+*
+*     The name has been changed in order to avoid symbol collision with 
+*     the newer version of PDLAMCH in Scalapack which can not be used
+*     with MPI context.
 *
 *     .. Scalar Arguments ..
       CHARACTER          CMACH
@@ -20,7 +24,7 @@
 *  =========
 *
 *  ICTXT   (global input) INTEGER
-*          The BLACS context handle in which the computation takes
+*          The MPI context handle in which the computation takes
 *          place.
 *
 *  CMACH   (global input) CHARACTER*1

--- a/PARPACK/SRC/MPI/pdnaitr.f
+++ b/PARPACK/SRC/MPI/pdnaitr.f
@@ -142,7 +142,7 @@ c     arscnd   ARPACK utility routine for timing.
 c     pdmout   Parallel ARPACK utility routine that prints matrices
 c     pdvout   Parallel ARPACK utility routine that prints vectors.
 c     dlabad   LAPACK routine that computes machine constants.
-c     pdlamch  ScaLAPACK routine that determines machine constants.
+c     pdlamch10 ScaLAPACK routine that determines machine constants.
 c     dlascl   LAPACK routine for careful scaling of a matrix.
 c     dlanhs   LAPACK routine that computes various norms of a matrix.
 c     dgemv    Level 2 BLAS routine for matrix vector multiplication.
@@ -297,8 +297,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision
-     &           ddot, pdnorm2, dlanhs, pdlamch
-      external   ddot, pdnorm2, dlanhs, pdlamch
+     &           ddot, pdnorm2, dlanhs, pdlamch10
+      external   ddot, pdnorm2, dlanhs, pdlamch10
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -326,10 +326,10 @@ c        | overflow should not occur.              |
 c        | REFERENCE: LAPACK subroutine dlahqr     |
 c        %-----------------------------------------%
 c
-         unfl = pdlamch(comm, 'safe minimum' )
+         unfl = pdlamch10(comm, 'safe minimum' )
          ovfl = one / unfl
          call dlabad( unfl, ovfl )
-         ulp = pdlamch( comm, 'precision' )
+         ulp = pdlamch10( comm, 'precision' )
          smlnum = unfl*( n / ulp )
          first = .false.
       end if

--- a/PARPACK/SRC/MPI/pdnapps.f
+++ b/PARPACK/SRC/MPI/pdnapps.f
@@ -102,7 +102,7 @@ c
 c\Routines called:
 c     dlabad  LAPACK routine that computes machine constants.
 c     dlacpy  LAPACK matrix copy routine.
-c     pdlamch ScaLAPACK routine that determines machine constants.
+c     pdlamch10 ScaLAPACK routine that determines machine constants.
 c     dlanhs  LAPACK routine that computes various norms of a matrix.
 c     dlapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     dlarf   LAPACK routine that applies Householder reflection to
@@ -205,8 +205,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision
-     &           pdlamch, dlanhs, dlapy2
-      external   pdlamch, dlanhs, dlapy2
+     &           pdlamch10, dlanhs, dlapy2
+      external   pdlamch10, dlanhs, dlapy2
 c
 c     %----------------------%
 c     | Intrinsics Functions |
@@ -233,10 +233,10 @@ c        | overflow should not occur.                    |
 c        | REFERENCE: LAPACK subroutine dlahqr           |
 c        %-----------------------------------------------%
 c
-         unfl = pdlamch( comm, 'safe minimum' )
+         unfl = pdlamch10( comm, 'safe minimum' )
          ovfl = one / unfl
          call dlabad( unfl, ovfl )
-         ulp = pdlamch( comm, 'precision' )
+         ulp = pdlamch10( comm, 'precision' )
          smlnum = unfl*( n / ulp )
          first = .false.
       end if

--- a/PARPACK/SRC/MPI/pdnaup2.f
+++ b/PARPACK/SRC/MPI/pdnaup2.f
@@ -148,7 +148,7 @@ c     pivout   Parallel ARPACK utility routine that prints integers.
 c     arscnd   ARPACK utility routine for timing.
 c     pdmout    Parallel ARPACK utility routine that prints matrices
 c     pdvout    ARPACK utility routine that prints vectors.
-c     pdlamch   ScaLAPACK routine that determines machine constants.
+c     pdlamch10   ScaLAPACK routine that determines machine constants.
 c     dlapy2    LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     dcopy     Level 1 BLAS that copies one vector to another .
 c     ddot      Level 1 BLAS that computes the scalar product of two vectors. 
@@ -262,8 +262,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision 
-     &           ddot , pdnorm2 , dlapy2 , pdlamch 
-      external   ddot , pdnorm2 , dlapy2 , pdlamch 
+     &           ddot , pdnorm2 , dlapy2 , pdlamch10 
+      external   ddot , pdnorm2 , dlapy2 , pdlamch10 
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -285,7 +285,7 @@ c        %-------------------------------------%
 c        | Get the machine dependent constant. |
 c        %-------------------------------------%
 c
-         eps23 = pdlamch (comm, 'Epsilon-Machine')
+         eps23 = pdlamch10 (comm, 'Epsilon-Machine')
          eps23 = eps23**(2.0  / 3.0 )
 c
          nev0   = nev

--- a/PARPACK/SRC/MPI/pdnaupd.f
+++ b/PARPACK/SRC/MPI/pdnaupd.f
@@ -384,7 +384,7 @@ c              Arnoldi Iteration.
 c     pivout   Parallel ARPACK utility routine that prints integers.
 c     arscnd   ARPACK utility routine for timing.
 c     pdvout    Parallel ARPACK utility routine that prints vectors.
-c     pdlamch   ScaLAPACK routine that determines machine constants.
+c     pdlamch10   ScaLAPACK routine that determines machine constants.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
@@ -475,8 +475,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision 
-     &           pdlamch 
-      external   pdlamch 
+     &           pdlamch10 
+      external   pdlamch10 
 c
 c     %-----------------------%
 c     | Executable Statements |
@@ -553,7 +553,7 @@ c        | Set default parameters |
 c        %------------------------%
 c
          if (nb .le. 0)	nb = 1
-         if (tol .le. zero)	tol = pdlamch (comm, 'EpsMach')
+         if (tol .le. zero)	tol = pdlamch10 (comm, 'EpsMach')
 c
 c        %----------------------------------------------%
 c        | NP is the number of additional steps to      |

--- a/PARPACK/SRC/MPI/pdneupd.f
+++ b/PARPACK/SRC/MPI/pdneupd.f
@@ -238,7 +238,7 @@ c             a matrix.
 c     dlacpy   LAPACK matrix copy routine.
 c     dlahqr   LAPACK routine to compute the real Schur form of an
 c             upper Hessenberg matrix.
-c     pdlamch  ScaLAPACK routine that determines machine constants.
+c     pdlamch10  ScaLAPACK routine that determines machine constants.
 c     dlapy2   LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     dlaset   LAPACK matrix initialization routine.
 c     dorm2r   LAPACK routine that applies an orthogonal matrix in 
@@ -388,8 +388,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision 
-     &           dlapy2 , dnrm2 , pdlamch 
-      external   dlapy2 , dnrm2 , pdlamch 
+     &           dlapy2 , dnrm2 , pdlamch10 
+      external   dlapy2 , dnrm2 , pdlamch10 
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -414,7 +414,7 @@ c     %---------------------------------%
 c     | Get machine dependent constant. |
 c     %---------------------------------%
 c
-      eps23 = pdlamch (comm, 'Epsilon-Machine')
+      eps23 = pdlamch10 (comm, 'Epsilon-Machine')
       eps23 = eps23**(2.0  / 3.0 )
 c
 c     %--------------%

--- a/PARPACK/SRC/MPI/pdsaitr.f
+++ b/PARPACK/SRC/MPI/pdsaitr.f
@@ -139,7 +139,7 @@ c     pdgetv0  Parallel ARPACK routine to generate the initial vector.
 c     pivout   Parallel ARPACK utility routine that prints integers.
 c     pdmout   Parallel ARPACK utility routine that prints matrices.
 c     pdvout   Parallel ARPACK utility routine that prints vectors.
-c     pdlamch  ScaLAPACK routine that determines machine constants.
+c     pdlamch10  ScaLAPACK routine that determines machine constants.
 c     dlascl   LAPACK routine for careful scaling of a matrix.
 c     dgemv    Level 2 BLAS routine for matrix vector multiplication.
 c     daxpy    Level 1 BLAS that computes a vector triad.
@@ -290,8 +290,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision
-     &           ddot, pdnorm2, pdlamch
-      external   ddot, pdnorm2, pdlamch
+     &           ddot, pdnorm2, pdlamch10
+      external   ddot, pdnorm2, pdlamch10
 c
 c     %-----------------%
 c     | Data statements |
@@ -318,7 +318,7 @@ c        | safmin = safe minimum is such  |
 c        | that 1/sfmin does not overflow |
 c        %--------------------------------%
 c
-         safmin = pdlamch(comm,'safmin')
+         safmin = pdlamch10(comm,'safmin')
       end if
 c
       if (ido .eq. 0) then

--- a/PARPACK/SRC/MPI/pdsapps.f
+++ b/PARPACK/SRC/MPI/pdsapps.f
@@ -95,7 +95,7 @@ c\Routines called:
 c     pivout  Parallel ARPACK utility routine that prints integers. 
 c     arscnd  ARPACK utility routine for timing.
 c     pdvout  Parallel ARPACK utility routine that prints vectors.
-c     pdlamch ScaLAPACK routine that determines machine constants.
+c     pdlamch10 ScaLAPACK routine that determines machine constants.
 c     dlartg  LAPACK Givens rotation construction routine.
 c     dlacpy  LAPACK matrix copy routine.
 c     dlaset  LAPACK matrix initialization routine.
@@ -194,8 +194,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision
-     &           pdlamch
-      external   pdlamch
+     &           pdlamch10
+      external   pdlamch10
 c
 c     %----------------------%
 c     | Intrinsics Functions |
@@ -214,7 +214,7 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (first) then
-         epsmch = pdlamch(comm, 'Epsilon-Machine')
+         epsmch = pdlamch10(comm, 'Epsilon-Machine')
          first = .false.
       end if
       itop = 1

--- a/PARPACK/SRC/MPI/pdsaup2.f
+++ b/PARPACK/SRC/MPI/pdsaup2.f
@@ -155,7 +155,7 @@ c              tridiagonal matrix using the implicit QL or QR method.
 c     pivout   Parallel ARPACK utility routine that prints integers.
 c     arscnd   ARPACK utility routine for timing.
 c     pdvout   Parallel ARPACK utility routine that prints vectors.
-c     pdlamch  ScaLAPACK routine that determines machine constants.
+c     pdlamch10  ScaLAPACK routine that determines machine constants.
 c     dcopy    Level 1 BLAS that copies one vector to another.
 c     ddot     Level 1 BLAS that computes the scalar product of two vectors.
 c     pdnorm2  Parallel version of Level 1 BLAS that computes the norm of a vector.
@@ -263,8 +263,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision
-     &           ddot, pdnorm2, pdlamch
-      external   ddot, pdnorm2, pdlamch
+     &           ddot, pdnorm2, pdlamch10
+      external   ddot, pdnorm2, pdlamch10
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -290,7 +290,7 @@ c        %---------------------------------%
 c        | Set machine dependent constant. |
 c        %---------------------------------%
 c
-         eps23 = pdlamch(comm, 'Epsilon-Machine')
+         eps23 = pdlamch10(comm, 'Epsilon-Machine')
          eps23 = eps23**(2.0/3.0)
 c
 c        %-------------------------------------%

--- a/PARPACK/SRC/MPI/pdsaupd.f
+++ b/PARPACK/SRC/MPI/pdsaupd.f
@@ -386,7 +386,7 @@ c              variables.
 c     pivout   Parallel ARPACK utility routine that prints integers.
 c     arscnd   ARPACK utility routine for timing.
 c     pdvout    Parallel ARPACK utility routine that prints vectors.
-c     pdlamch   ScaLAPACK routine that determines machine constants.
+c     pdlamch10   ScaLAPACK routine that determines machine constants.
 c
 c\Authors
 c     Kristi Maschhoff ( Parallel Code )
@@ -479,8 +479,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision 
-     &           pdlamch 
-      external   pdlamch 
+     &           pdlamch10 
+      external   pdlamch10 
 c
 c     %-----------------------%
 c     | Executable Statements |
@@ -563,7 +563,7 @@ c        | Set default parameters |
 c        %------------------------%
 c
          if (nb .le. 0) nb = 1
-         if (tol .le. zero) tol = pdlamch (comm, 'EpsMach')
+         if (tol .le. zero) tol = pdlamch10 (comm, 'EpsMach')
 c
 c        %----------------------------------------------%
 c        | NP is the number of additional steps to      |

--- a/PARPACK/SRC/MPI/pdseupd.f
+++ b/PARPACK/SRC/MPI/pdseupd.f
@@ -191,7 +191,7 @@ c     pdvout  Parallel ARPACK utility routine that prints vectors.
 c     dgeqr2  LAPACK routine that computes the QR factorization of
 c             a matrix.
 c     dlacpy  LAPACK matrix copy routine.
-c     pdlamch ScaLAPACK routine that determines machine constants.
+c     pdlamch10 ScaLAPACK routine that determines machine constants.
 c     dorm2r  LAPACK routine that applies an orthogonal matrix in
 c             factored form.
 c     dsteqr  LAPACK routine that computes eigenvalues and eigenvectors
@@ -295,8 +295,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision
-     &           pdnorm2, pdlamch
-      external   pdnorm2, pdlamch
+     &           pdnorm2, pdlamch10
+      external   pdnorm2, pdlamch10
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -439,7 +439,7 @@ c     %---------------------------------%
 c     | Set machine dependent constant. |
 c     %---------------------------------%
 c
-      eps23 = pdlamch(comm, 'Epsilon-Machine') 
+      eps23 = pdlamch10(comm, 'Epsilon-Machine') 
       eps23 = eps23**(2.0 / 3.0)
 c
 c     %---------------------------------------%

--- a/PARPACK/SRC/MPI/pznaitr.f
+++ b/PARPACK/SRC/MPI/pznaitr.f
@@ -144,7 +144,7 @@ c     zlanhs    LAPACK routine that computes various norms of a matrix.
 c     zlascl    LAPACK routine for careful scaling of a matrix.
 c     dlabad    LAPACK routine for defining the underflow and overflow
 c               limits
-c     pdlamch   ScaLAPACK routine that determines machine constants.
+c     pdlamch10   ScaLAPACK routine that determines machine constants.
 c     dlapy2    LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     zgemv     Level 2 BLAS routine for matrix vector multiplication.
 c     zaxpy     Level 1 BLAS that computes a vector triad.
@@ -308,8 +308,8 @@ c
       Complex*16
      &           zdotc 
       Double precision            
-     &           pdlamch, pdznorm2, zlanhs, dlapy2
-      external   zdotc, pdznorm2, zlanhs, pdlamch, dlapy2
+     &           pdlamch10, pdznorm2, zlanhs, dlapy2
+      external   zdotc, pdznorm2, zlanhs, pdlamch10, dlapy2
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -337,10 +337,10 @@ c        | overflow should not occur.              |
 c        | REFERENCE: LAPACK subroutine zlahqr     |
 c        %-----------------------------------------%
 c
-         unfl = pdlamch(comm,  'safe minimum' )
+         unfl = pdlamch10(comm,  'safe minimum' )
          ovfl = dble(one / unfl)
          call dlabad( unfl, ovfl )
-         ulp = pdlamch( comm, 'precision' )
+         ulp = pdlamch10( comm, 'precision' )
          smlnum = unfl*( n / ulp )
          first = .false.
       end if

--- a/PARPACK/SRC/MPI/pznapps.f
+++ b/PARPACK/SRC/MPI/pznapps.f
@@ -105,7 +105,7 @@ c     zlartg  LAPACK Givens rotation construction routine.
 c     zlaset  LAPACK matrix initialization routine.
 c     dlabad  LAPACK routine for defining the underflow and overflow
 c             limits.
-c     pdlamch ScaLAPACK routine that determines machine constants.
+c     pdlamch10 ScaLAPACK routine that determines machine constants.
 c     dlapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     zgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     zaxpy   Level 1 BLAS that computes a vector triad.
@@ -207,8 +207,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision                 
-     &           zlanhs, pdlamch, dlapy2
-      external   zlanhs, pdlamch, dlapy2
+     &           zlanhs, pdlamch10, dlapy2
+      external   zlanhs, pdlamch10, dlapy2
 c
 c     %----------------------%
 c     | Intrinsics Functions |
@@ -243,10 +243,10 @@ c        | overflow should not occur.                    |
 c        | REFERENCE: LAPACK subroutine zlahqr           |
 c        %-----------------------------------------------%
 c
-         unfl = pdlamch( comm, 'safe minimum' )
+         unfl = pdlamch10( comm, 'safe minimum' )
          ovfl = dble(one / unfl)
          call dlabad( unfl, ovfl )
-         ulp = pdlamch( comm, 'precision' )
+         ulp = pdlamch10( comm, 'precision' )
          smlnum = unfl*( n / ulp )
          first = .false.
       end if

--- a/PARPACK/SRC/MPI/pznaup2.f
+++ b/PARPACK/SRC/MPI/pznaup2.f
@@ -141,7 +141,7 @@ c     arscnd   ARPACK utility routine for timing.
 c     pzmout   Parallel ARPACK utility routine that prints matrices
 c     pzvout   Parallel ARPACK utility routine that prints vectors.
 c     pdvout   ARPACK utility routine that prints vectors.
-c     pdlamch  ScaLAPACK routine that determines machine constants.
+c     pdlamch10  ScaLAPACK routine that determines machine constants.
 c     dlapy2   LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     zcopy    Level 1 BLAS that copies one vector to another .
 c     zdotc    Level 1 BLAS that computes the scalar product of two vectors. 
@@ -259,8 +259,8 @@ c
       Complex*16
      &           zdotc
       Double precision  
-     &           pdznorm2, pdlamch, dlapy2
-      external   zdotc, pdznorm2, pdlamch, dlapy2
+     &           pdznorm2, pdlamch10, dlapy2
+      external   zdotc, pdznorm2, pdlamch10, dlapy2
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -298,7 +298,7 @@ c        %---------------------------------%
 c        | Get machine dependent constant. |
 c        %---------------------------------%
 c
-         eps23 = pdlamch(comm, 'Epsilon-Machine')
+         eps23 = pdlamch10(comm, 'Epsilon-Machine')
          eps23 = eps23**(2.0 / 3.0)
 c
 c        %---------------------------------------%

--- a/PARPACK/SRC/MPI/pznaupd.f
+++ b/PARPACK/SRC/MPI/pznaupd.f
@@ -108,7 +108,7 @@ c  TOL     Double precision   scalar.  (INPUT)
 c          Stopping criteria: the relative accuracy of the Ritz value 
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I))
 c          where ABS(RITZ(I)) is the magnitude when RITZ(I) is complex.
-c          DEFAULT = pdlamch (comm, 'EPS')  (machine precision as computed
+c          DEFAULT = pdlamch10 (comm, 'EPS')  (machine precision as computed
 c                    by the ScaLAPACK auxiliary subroutine pdlamch ).
 c
 c  RESID   Complex*16  array of length N.  (INPUT/OUTPUT)
@@ -360,7 +360,7 @@ c     zstatn    ARPACK routine that initializes the timing variables.
 c     pivout   Parallel ARPACK utility routine that prints integers.
 c     pzvout    Parallel ARPACK utility routine that prints vectors.
 c     arscnd   ARPACK utility routine for timing.
-c     pdlamch   ScaLAPACK routine that determines machine constants.
+c     pdlamch10   ScaLAPACK routine that determines machine constants.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
@@ -453,8 +453,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision  
-     &           pdlamch 
-      external   pdlamch 
+     &           pdlamch10 
+      external   pdlamch10 
 c
 c     %-----------------------%
 c     | Executable Statements |
@@ -529,7 +529,7 @@ c        | Set default parameters |
 c        %------------------------%
 c
          if (nb .le. 0)	nb = 1
-         if (tol .le. 0.0  ) tol = pdlamch (comm, 'EpsMach')
+         if (tol .le. 0.0  ) tol = pdlamch10 (comm, 'EpsMach')
          if (ishift .ne. 0  .and.  
      &       ishift .ne. 1  .and.
      &       ishift .ne. 2)	ishift = 1

--- a/PARPACK/SRC/MPI/pzneupd.f
+++ b/PARPACK/SRC/MPI/pzneupd.f
@@ -213,7 +213,7 @@ c             in upper triangular form.
 c     ztrsen  LAPACK routine that re-orders the Schur form.
 c     zunm2r  LAPACK routine that applies an orthogonal matrix in 
 c             factored form.
-c     pdlamch ScaLAPACK routine that determines machine constants.
+c     pdlamch10 ScaLAPACK routine that determines machine constants.
 c     ztrmm   Level 3 BLAS matrix times an upper triangular matrix.
 c     zgeru   Level 2 BLAS rank one update to a matrix.
 c     zcopy   Level 1 BLAS that copies one vector to another .
@@ -336,8 +336,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Double precision
-     &           dznrm2,pdlamch,dlapy2
-      external   dznrm2,pdlamch,dlapy2
+     &           dznrm2,pdlamch10,dlapy2
+      external   dznrm2,pdlamch10,dlapy2
 c
       Complex*16
      &           zdotc
@@ -367,7 +367,7 @@ c     %---------------------------------%
 c     | Get machine dependent constant. |
 c     %---------------------------------%
 c
-      eps23 = pdlamch(comm, 'Epsilon-Machine')
+      eps23 = pdlamch10(comm, 'Epsilon-Machine')
       eps23 = eps23**(2.0 / 3.0)
 c
 c     %-------------------------------%


### PR DESCRIPTION
…2.0.2 where this function is different.

should fix https://github.com/opencollab/arpack-ng/issues/18 but until https://github.com/opencollab/arpack-ng/pull/19 is merged I can't test it on my mac.