### PR TITLE
removing AC_FC_LINE_LENGTH to solve #41 on Cygwin

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 arpack-ng - 3.5.0
 
+ [ Marco Atzeri]
+ * Use AC_PROG_FC instead of AC_PROG_F77 for proper inizialization
+   for the usage of AC_FC_LINE_LENGTH. Noted on Cygwin.
+
  [ Denis Davydov ]
  * Improve cmake build system: add make install and fix shared libraries.
 

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,6 @@ AC_ARG_VAR(SYMBOLSUFFIX, [suffix to add to ARPACK, BLAS and LAPACK function name
 
 if test x"$SYMBOLSUFFIX" != x""; then
   dnl Need to rely on non-F77 features
-  AC_FC_LINE_LENGTH(unlimited)
   FFLAGS="$FFLAGS $ac_cv_fc_line_length"
 
   AX_CHECK_COMPILE_FLAG(-cpp, FFLAGS="$FFLAGS -cpp",

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_LINKS([TESTS/testA.mtx:TESTS/testA.mtx])
 
 dnl Checks for standard programs.
-AC_PROG_F77
+AC_PROG_FC
 AC_PROG_CC
 
 dnl Check for BLAS libraries
@@ -37,6 +37,7 @@ AC_ARG_VAR(SYMBOLSUFFIX, [suffix to add to ARPACK, BLAS and LAPACK function name
 
 if test x"$SYMBOLSUFFIX" != x""; then
   dnl Need to rely on non-F77 features
+  AC_FC_LINE_LENGTH(unlimited)
   FFLAGS="$FFLAGS $ac_cv_fc_line_length"
 
   AX_CHECK_COMPILE_FLAG(-cpp, FFLAGS="$FFLAGS -cpp",


### PR DESCRIPTION
Tested on latest Cygwin 32 and 64bit. No test failure.

No idea why "AC_FC_LINE_LENGTH(unlimited)" was introduced but I guess mixing F77 with FC  commands is confusing Autoconf at least on Cygwin in this case

$ gfortran --version
GNU Fortran (GCC) 5.4.0
