### PR TITLE
fix usages of DLACPY to not alias inputs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,9 @@ arpack-ng - 3.5.0
 
  [ Denis Davydov ]
  * Improve cmake build system: add make install and fix shared libraries.
+ 
+ [ Zhang Z ]
+ * fix usages of DLACPY to not alias inputs
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Sun, 03 Jul 2016 21:51:52 +0200
 

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ arpack-ng - 3.5.0
  
  [ Zhang Z ]
  * fix usages of DLACPY to not alias inputs
+   (patch from https://software.intel.com/en-us/articles/how-to-resolve-arpack-issues-with-intel-mkl-110-update-3)
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Sun, 03 Jul 2016 21:51:52 +0200
 

--- a/SRC/dnapps.f
+++ b/SRC/dnapps.f
@@ -599,7 +599,9 @@ c     %-------------------------------------------------%
 c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
-      call dlacpy ('A', n, kev, v(1,kplusp-kev+1), ldv, v, ldv)
+      do 150 i = 1, kev
+         call dcopy(n, v(1,kplusp-kev+i), 1, v(1,i), 1)
+  150 continue
 c 
 c     %--------------------------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the appropriate place |

--- a/SRC/dsapps.f
+++ b/SRC/dsapps.f
@@ -468,7 +468,9 @@ c     %-------------------------------------------------%
 c     |  Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev). |
 c     %-------------------------------------------------%
 c
-      call dlacpy ('All', n, kev, v(1,np+1), ldv, v, ldv)
+      do 140 i = 1, kev
+         call dcopy (n, v(1,np+i), 1, v(1,i), 1)
+  140 continue
 c 
 c     %--------------------------------------------%
 c     | Copy the (kev+1)-st column of (V*Q) in the |


### PR DESCRIPTION
I came across this patch online, although the issue doesn't personally affect me, it said "We have contacted the ARPACK developers and made them aware of this issue", so it seemed worth suggesting it here.

https://software.intel.com/en-us/articles/how-to-resolve-arpack-issues-with-intel-mkl-110-update-3