### PR TITLE
CMake: find_package for both parpack and arpack (for now, works only for arpack).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,9 +473,9 @@ if (MPI)
 endif ()
 
 # Provide find_package for arpack-ng to users.
-configure_file(arpack-ng-config.cmake.in "${PROJECT_BINARY_DIR}/arpack-ng-config.cmake")
+configure_file(arpack-ng-config.cmake.in "${PROJECT_BINARY_DIR}/arpack-ng-config.cmake" @ONLY)
 install(FILES "${PROJECT_BINARY_DIR}/arpack-ng-config.cmake" DESTINATION "${CMAKE_INSTALL_PREFIX}") # find_package(arpack-ng)
-configure_file(arpack-ng-config.cmake.in "${PROJECT_BINARY_DIR}/arpack-ngConfig.cmake")
+configure_file(arpack-ng-config.cmake.in "${PROJECT_BINARY_DIR}/arpack-ngConfig.cmake" @ONLY)
 install(FILES "${PROJECT_BINARY_DIR}/arpack-ngConfig.cmake" DESTINATION "${CMAKE_INSTALL_PREFIX}") # find_package(arpack-ng)
 set(arpack_ng_MAJOR_VERSION 3)
 set(arpack_ng_MINOR_VERSION 6)

--- a/arpack-ng-config.cmake.in
+++ b/arpack-ng-config.cmake.in
@@ -1,9 +1,14 @@
 # Config file for the arpack-ng package. It defines the following variables:
 # - arpack_ng_INCLUDE_DIRS - include directories
 # - arpack_ng_LIBRARIES    - libraries to link against
-set(arpack_ng_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "arpack-ng: include directories" FORCE)
-if(EXISTS "${CMAKE_INSTALL_PREFIX}/lib/libarpack.a")
-  set(arpack_ng_LIBRARIES "${CMAKE_INSTALL_PREFIX}/lib/libarpack.a" CACHE FILEPATH "arpack-ng: libraries" FORCE)
-elseif(EXISTS "${CMAKE_INSTALL_PREFIX}/lib/libarpack.so")
-  set(arpack_ng_LIBRARIES "${CMAKE_INSTALL_PREFIX}/lib/libarpack.so" CACHE FILEPATH "arpack-ng: libraries" FORCE)
+set(arpack_ng_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include" CACHE PATH "arpack-ng: include directories" FORCE)
+if(EXISTS "@CMAKE_INSTALL_PREFIX@/lib/libarpack.a")
+  set(arpack_ng_LIBRARIES "@CMAKE_INSTALL_PREFIX@/lib/libarpack.a" CACHE FILEPATH "arpack-ng: libraries" FORCE)
+elseif(EXISTS "@CMAKE_INSTALL_PREFIX@/lib/libarpack.so")
+  set(arpack_ng_LIBRARIES "@CMAKE_INSTALL_PREFIX@/lib/libarpack.so" CACHE FILEPATH "arpack-ng: libraries" FORCE)
+endif()
+if(EXISTS "@CMAKE_INSTALL_PREFIX@/lib/libparpack.a")
+  set(arpack_ng_LIBRARIES "@CMAKE_INSTALL_PREFIX@/lib/libparpack.a;${arpack_ng_LIBRARIES}" CACHE FILEPATH "arpack-ng: libraries" FORCE)
+elseif(EXISTS "@CMAKE_INSTALL_PREFIX@/lib/libparpack.so")
+  set(arpack_ng_LIBRARIES "@CMAKE_INSTALL_PREFIX@/lib/libparpack.so;${arpack_ng_LIBRARIES}" CACHE FILEPATH "arpack-ng: libraries" FORCE)
 endif()


### PR DESCRIPTION
CMake: find_package for both parpack and arpack (for now, works only for arpack).

/tmp> cp /path/to/arpack-ng/PARPACK/EXAMPLES/MPI/*.f .
/tmp> cp /path/to/arpack-ng/PARPACK/EXAMPLES/MPI/*.h .

/tmp> more CMakeLists.txt
cmake_minimum_required(VERSION 3.7)
project(pdndrv1 Fortran)
find_package(MPI REQUIRED)
find_package(arpack-ng 3.5 REQUIRED)
find_package(BLAS REQUIRED)
find_package(LAPACK REQUIRED)
add_executable(pdndrv1 pdndrv1.f)
target_link_libraries(pdndrv1 "${arpack_ng_LIBRARIES}" "${MPI_Fortran_LIBRARIES}" "${BLAS_LIBRARIES}" "${LAPACK_LIBRARIES}")
target_include_directories(pdndrv1 PUBLIC "${arpack_ng_INCLUDE_DIRS}" "${MPI_Fortran_INCLUDE_PATH}")

/tmp> export CMAKE_PREFIX_PATH=/path/to/arpack-ng/local # Should be done by module load.

/tmp> mkdir BUILD; cd BUILD; cmake ..; make

/tmp> mpirun -n 2 ./pdndrv1