### PR TITLE
Fix C and C++ bindings ABI

### DIFF
--- a/TESTS/icb_arpack_c.c
+++ b/TESTS/icb_arpack_c.c
@@ -43,7 +43,7 @@ int ds() {
   bool rvec = true;
   char howmny[] = "A";
   double* d = (double*) malloc((nev+1)*sizeof(double));
-  bool select[3*ncv];
+  int select[ncv];
   double z[(N+1)*(nev+1)];
   BLASINT ldz = N+1;
   double sigma=0;
@@ -110,7 +110,7 @@ int zn() {
   bool rvec = true;
   char howmny[] = "A";
   double _Complex* d = (double _Complex*) malloc((nev+1)*sizeof(double _Complex));
-  bool select[3*ncv];
+  int select[ncv];
   double _Complex z[(N+1)*(nev+1)];
   BLASINT ldz = N+1;
   double sigma=0;

--- a/TESTS/icb_arpack_cpp.cpp
+++ b/TESTS/icb_arpack_cpp.cpp
@@ -41,7 +41,7 @@ int ss() {
   bool rvec = true;
   char howmny[] = "A";
   float* d = (float*) new float[(nev+1)];
-  bool select[3*ncv];
+  int select[ncv];
   float z[(N+1)*(nev+1)];
   BLASINT ldz = N+1;
   float sigma=0;
@@ -108,7 +108,7 @@ int cn() {
   bool rvec = true;
   char howmny[] = "A";
   float _Complex* d = (float _Complex*) new float _Complex[(nev+1)];
-  bool select[3*ncv];
+  int select[ncv];
   float _Complex z[(N+1)*(nev+1)];
   BLASINT ldz = N+1;
   float sigma=0;

--- a/arpack.h
+++ b/arpack.h
@@ -6,7 +6,7 @@ extern void ssaupd_c(int * ido, char * bmat, int n, char * which, int nev,
                      int ldv, int * iparam, int * ipntr, float * workd,
                      float * workl, int lworkl, int * info);
 
-extern void sseupd_c(bool rvec, char * howmny, bool * select, float * d, float * z, int ldz, float sigma,
+extern void sseupd_c(bool rvec, char * howmny, int * select, float * d, float * z, int ldz, float sigma,
                      char * bmat, int n, char * which, int nev,
                      float tol, float * resid, int ncv, float * v,
                      int ldv, int * iparam, int * ipntr, float * workd,
@@ -17,7 +17,7 @@ extern void dsaupd_c(int * ido, char * bmat, int n, char * which, int nev,
                      int ldv, int * iparam, int * ipntr, double * workd,
                      double * workl, int lworkl, int * info);
 
-extern void dseupd_c(bool rvec, char * howmny, bool * select, double * d, double * z, int ldz, double sigma,
+extern void dseupd_c(bool rvec, char * howmny, int * select, double * d, double * z, int ldz, double sigma,
                      char * bmat, int n, char * which, int nev,
                      double tol, double * resid, int ncv, double * v,
                      int ldv, int * iparam, int * ipntr, double * workd,
@@ -28,7 +28,7 @@ extern void snaupd_c(int * ido, char * bmat, int n, char * which, int nev,
                      int ldv, int * iparam, int * ipntr, float * workd,
                      float * workl, int lworkl, int * info);
 
-extern void sneupd_c(bool rvec, char * howmny, bool * select, float * dr, float * di, float * z, int ldz, float sigmar, float sigmai,
+extern void sneupd_c(bool rvec, char * howmny, int * select, float * dr, float * di, float * z, int ldz, float sigmar, float sigmai,
                      char * bmat, int n, char * which, int nev,
                      float tol, float * resid, int ncv, float * v,
                      int ldv, int * iparam, int * ipntr, float * workd,
@@ -39,7 +39,7 @@ extern void dnaupd_c(int * ido, char * bmat, int n, char * which, int nev,
                      int ldv, int * iparam, int * ipntr, double * workd,
                      double * workl, int lworkl, int * info);
 
-extern void dneupd_c(bool rvec, char * howmny, bool * select, double * dr, double * di, double * z, int ldz, double sigmar, double sigmai,
+extern void dneupd_c(bool rvec, char * howmny, int * select, double * dr, double * di, double * z, int ldz, double sigmar, double sigmai,
                      char * bmat, int n, char * which, int nev,
                      double tol, double * resid, int ncv, double * v,
                      int ldv, int * iparam, int * ipntr, double * workd,
@@ -50,7 +50,7 @@ extern void cnaupd_c(int * ido, char * bmat, int n, char * which, int nev,
                      int ldv, int * iparam, int * ipntr, float _Complex * workd,
                      float _Complex * workl, int lworkl, float _Complex * rwork, int * info);
 
-extern void cneupd_c(bool rvec, char * howmny, bool * select,
+extern void cneupd_c(bool rvec, char * howmny, int * select,
                      float _Complex * d, float _Complex * z, int ldz, float _Complex sigma, float _Complex * workev,
                      char * bmat, int n, char * which, int nev,
                      float tol, float _Complex * resid, int ncv, float _Complex * v,
@@ -62,7 +62,7 @@ extern void znaupd_c(int * ido, char * bmat, int n, char * which, int nev,
                      int ldv, int * iparam, int * ipntr, double _Complex * workd,
                      double _Complex * workl, int lworkl, double _Complex * rwork, int * info);
 
-extern void zneupd_c(bool rvec, char * howmny, bool * select,
+extern void zneupd_c(bool rvec, char * howmny, int * select,
                      double _Complex * d, double _Complex * z, int ldz, double _Complex sigma, double _Complex * workev,
                      char * bmat, int n, char * which, int nev,
                      double tol, double _Complex * resid, int ncv, double _Complex * v,

--- a/arpack.hpp
+++ b/arpack.hpp
@@ -6,7 +6,7 @@ extern "C" void ssaupd_c(int & ido, char * bmat, int n, char * which, int nev,
                          int ldv, int * iparam, int * ipntr, float * workd,
                          float * workl, int lworkl, int & info);
 
-extern "C" void sseupd_c(bool rvec, char * howmny, bool * select, float * d, float * z, int ldz, float sigma,
+extern "C" void sseupd_c(bool rvec, char * howmny, int * select, float * d, float * z, int ldz, float sigma,
                          char * bmat, int n, char * which, int nev,
                          float tol, float * resid, int ncv, float * v,
                          int ldv, int * iparam, int * ipntr, float * workd,
@@ -17,7 +17,7 @@ extern "C" void dsaupd_c(int & ido, char * bmat, int n, char * which, int nev,
                          int ldv, int * iparam, int * ipntr, double * workd,
                          double * workl, int lworkl, int & info);
 
-extern "C" void dseupd_c(bool rvec, char * howmny, bool * select, double * d, double * z, int ldz, double sigma,
+extern "C" void dseupd_c(bool rvec, char * howmny, int * select, double * d, double * z, int ldz, double sigma,
                          char * bmat, int n, char * which, int nev,
                          double tol, double * resid, int ncv, double * v,
                          int ldv, int * iparam, int * ipntr, double * workd,
@@ -28,7 +28,7 @@ extern "C" void snaupd_c(int & ido, char * bmat, int n, char * which, int nev,
                          int ldv, int * iparam, int * ipntr, float * workd,
                          float * workl, int lworkl, int & info);
 
-extern "C" void sneupd_c(bool rvec, char * howmny, bool * select, float * dr, float * di, float * z, int ldz, float sigmar, float sigmai,
+extern "C" void sneupd_c(bool rvec, char * howmny, int * select, float * dr, float * di, float * z, int ldz, float sigmar, float sigmai,
                          char * bmat, int n, char * which, int nev,
                          float tol, float * resid, int ncv, float * v,
                          int ldv, int * iparam, int * ipntr, float * workd,
@@ -39,7 +39,7 @@ extern "C" void dnaupd_c(int & ido, char * bmat, int n, char * which, int nev,
                          int ldv, int * iparam, int * ipntr, double * workd,
                          double * workl, int lworkl, int & info);
 
-extern "C" void dneupd_c(bool rvec, char * howmny, bool * select, double * dr, double * di, double * z, int ldz, double sigmar, double sigmai,
+extern "C" void dneupd_c(bool rvec, char * howmny, int * select, double * dr, double * di, double * z, int ldz, double sigmar, double sigmai,
                          char * bmat, int n, char * which, int nev,
                          double tol, double * resid, int ncv, double * v,
                          int ldv, int * iparam, int * ipntr, double * workd,
@@ -50,7 +50,7 @@ extern "C" void cnaupd_c(int & ido, char * bmat, int n, char * which, int nev,
                          int ldv, int * iparam, int * ipntr, float _Complex * workd,
                          float _Complex * workl, int lworkl, float _Complex * rwork, int & info);
 
-extern "C" void cneupd_c(bool rvec, char * howmny, bool * select,
+extern "C" void cneupd_c(bool rvec, char * howmny, int * select,
                          float _Complex * d, float _Complex * z, int ldz, float _Complex sigma, float _Complex * workev,
                          char * bmat, int n, char * which, int nev,
                          float tol, float _Complex * resid, int ncv, float _Complex * v,
@@ -62,7 +62,7 @@ extern "C" void znaupd_c(int & ido, char * bmat, int n, char * which, int nev,
                          int ldv, int * iparam, int * ipntr, double _Complex * workd,
                          double _Complex * workl, int lworkl, double _Complex * rwork, int & info);
 
-extern "C" void zneupd_c(bool rvec, char * howmny, bool * select,
+extern "C" void zneupd_c(bool rvec, char * howmny, int * select,
                          double _Complex * d, double _Complex * z, int ldz, double _Complex sigma, double _Complex * workev,
                          char * bmat, int n, char * which, int nev,
                          double tol, double _Complex * resid, int ncv, double _Complex * v,


### PR DESCRIPTION
Fortran's logical type has size of 4 bytes, while C and C++ have `sizeof(bool)==1`. Thus it's no good to pass `bool[ncv]` array to a function expecting `logical(ncv)`.
Currently attempt to do this results in successful compilation and subsequent buffer overflow in e.g. `dseupd_c`. This is actually caught at run time by gcc>=5 by its stack smashing detector, leading to test failures.
This patch replaces `bool*` types expected by C and C++ bindings with `int*`, and corresponding declarations of the arrays in callers in the tests from `bool[3*ncv]` to `int[ncv]`.