### PR TITLE
rename pslamch to pslamch10 to avoid symbol collision with Scalapack

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 arpack-ng - 3.6.0
 
+ [ Denis Davydov ]
+ * Rename pslamch to pslamch10 to avoid symbol collision with Scalapack 2.0.2 in MPI context.
+
  [ Franck Houssen ]
  * Provide tarball generation using cmake (cpack).
  * Provide find_package for (cmake) users to find arpack-ng.

--- a/PARPACK/SRC/MPI/Makefile.am
+++ b/PARPACK/SRC/MPI/Makefile.am
@@ -20,7 +20,7 @@ ZSRC = pznaitr.f pznapps.f pznaup2.f pznaupd.f pzneigh.f pzneupd.f pzngets.f \
 EXTRA_DIST = debug.h stat.h pcontext.h
 
 noinst_LTLIBRARIES = libparpack@LIBSUFFIX@_noopt.la
-libparpack@LIBSUFFIX@_noopt_la_SOURCES = pslamch.f pdlamch10.f
+libparpack@LIBSUFFIX@_noopt_la_SOURCES = pslamch10.f pdlamch10.f
 libparpack@LIBSUFFIX@_noopt_la_FFLAGS = -O0
 
 lib_LTLIBRARIES = libparpack@LIBSUFFIX@.la

--- a/PARPACK/SRC/MPI/pcnaitr.f
+++ b/PARPACK/SRC/MPI/pcnaitr.f
@@ -144,7 +144,7 @@ c     clanhs    LAPACK routine that computes various norms of a matrix.
 c     clascl    LAPACK routine for careful scaling of a matrix.
 c     slabad    LAPACK routine for defining the underflow and overflow
 c               limits
-c     pslamch   ScaLAPACK routine that determines machine constants.
+c     pslamch10   ScaLAPACK routine that determines machine constants.
 c     slapy2    LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     cgemv     Level 2 BLAS routine for matrix vector multiplication.
 c     caxpy     Level 1 BLAS that computes a vector triad.
@@ -309,8 +309,8 @@ c
       Complex
      &           cdotc 
       Real            
-     &           pslamch, pscnorm2, clanhs, slapy2
-      external   cdotc, pscnorm2, clanhs, pslamch, slapy2
+     &           pslamch10, pscnorm2, clanhs, slapy2
+      external   cdotc, pscnorm2, clanhs, pslamch10, slapy2
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -337,10 +337,10 @@ c        | overflow should not occur.              |
 c        | REFERENCE: LAPACK subroutine clahqr     |
 c        %-----------------------------------------%
 c
-         unfl = pslamch(comm,  'safe minimum' )
+         unfl = pslamch10(comm,  'safe minimum' )
          ovfl = real(one / unfl)
          call slabad( unfl, ovfl )
-         ulp = pslamch( comm, 'precision' )
+         ulp = pslamch10( comm, 'precision' )
          smlnum = unfl*( n / ulp )
          aitr_first = .false.
       end if

--- a/PARPACK/SRC/MPI/pcnapps.f
+++ b/PARPACK/SRC/MPI/pcnapps.f
@@ -105,7 +105,7 @@ c     clartg  LAPACK Givens rotation construction routine.
 c     claset  LAPACK matrix initialization routine.
 c     slabad  LAPACK routine for defining the underflow and overflow
 c             limits.
-c     pslamch ScaLAPACK routine that determines machine constants.
+c     pslamch10 ScaLAPACK routine that determines machine constants.
 c     slapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     cgemv   Level 2 BLAS routine for matrix vector multiplication.
 c     caxpy   Level 1 BLAS that computes a vector triad.
@@ -207,8 +207,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real                 
-     &           clanhs, pslamch, slapy2
-      external   clanhs, pslamch, slapy2
+     &           clanhs, pslamch10, slapy2
+      external   clanhs, pslamch10, slapy2
 c
 c     %----------------------%
 c     | Intrinsics Functions |
@@ -242,10 +242,10 @@ c        | overflow should not occur.                    |
 c        | REFERENCE: LAPACK subroutine clahqr           |
 c        %-----------------------------------------------%
 c
-         unfl = pslamch( comm, 'safe minimum' )
+         unfl = pslamch10( comm, 'safe minimum' )
          ovfl = real(one / unfl)
          call slabad( unfl, ovfl )
-         ulp = pslamch( comm,  'precision' )
+         ulp = pslamch10( comm,  'precision' )
          smlnum = unfl*( n / ulp )
          apps_first = .false.
       end if

--- a/PARPACK/SRC/MPI/pcnaup2.f
+++ b/PARPACK/SRC/MPI/pcnaup2.f
@@ -141,7 +141,7 @@ c     arscnd   ARPACK utility routine for timing.
 c     pcmout   Parallel ARPACK utility routine that prints matrices
 c     pcvout   Parallel ARPACK utility routine that prints vectors.
 c     psvout   ARPACK utility routine that prints vectors.
-c     pslamch  ScaLAPACK routine that determines machine constants.
+c     pslamch10  ScaLAPACK routine that determines machine constants.
 c     slapy2   LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     ccopy    Level 1 BLAS that copies one vector to another .
 c     cdotc    Level 1 BLAS that computes the scalar product of two vectors. 
@@ -259,8 +259,8 @@ c
       Complex
      &           cdotc
       Real  
-     &           pscnorm2, pslamch, slapy2
-      external   cdotc, pscnorm2, pslamch, slapy2
+     &           pscnorm2, pslamch10, slapy2
+      external   cdotc, pscnorm2, pslamch10, slapy2
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -298,7 +298,7 @@ c        %---------------------------------%
 c        | Get machine dependent constant. |
 c        %---------------------------------%
 c
-         eps23 = pslamch(comm, 'Epsilon-Machine')
+         eps23 = pslamch10(comm, 'Epsilon-Machine')
          eps23 = eps23**(2.0 / 3.0)
 c
 c        %---------------------------------------%

--- a/PARPACK/SRC/MPI/pcnaupd.f
+++ b/PARPACK/SRC/MPI/pcnaupd.f
@@ -108,8 +108,8 @@ c  TOL     Real   scalar.  (INPUT)
 c          Stopping criteria: the relative accuracy of the Ritz value 
 c          is considered acceptable if BOUNDS(I) .LE. TOL*ABS(RITZ(I))
 c          where ABS(RITZ(I)) is the magnitude when RITZ(I) is complex.
-c          DEFAULT = pslamch(comm, 'EPS')  (machine precision as computed
-c                    by the ScaLAPACK auxiliary subroutine pslamch).
+c          DEFAULT = pslamch10(comm, 'EPS')  (machine precision as computed
+c                    by the ScaLAPACK auxiliary subroutine pslamch10).
 c
 c  RESID   Complex  array of length N.  (INPUT/OUTPUT)
 c          On INPUT: 
@@ -360,7 +360,7 @@ c     cstatn   ARPACK routine that initializes the timing variables.
 c     pivout   Parallel ARPACK utility routine that prints integers.
 c     pcvout   Parallel ARPACK utility routine that prints vectors.
 c     arscnd   ARPACK utility routine for timing.
-c     pslamch  ScaLAPACK routine that determines machine constants.
+c     pslamch10  ScaLAPACK routine that determines machine constants.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
@@ -454,8 +454,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real  
-     &           pslamch
-      external   pslamch
+     &           pslamch10
+      external   pslamch10
 c
 c     %-----------------------%
 c     | Executable Statements |
@@ -537,7 +537,7 @@ c        | Set default parameters |
 c        %------------------------%
 c
          if (nb .le. 0)	nb = 1
-         if (tol .le. 0.0  ) tol = pslamch(comm, 'EpsMach')
+         if (tol .le. 0.0  ) tol = pslamch10(comm, 'EpsMach')
          if (ishift .ne. 0  .and.  
      &       ishift .ne. 1  .and.
      &       ishift .ne. 2)	ishift = 1

--- a/PARPACK/SRC/MPI/pcneupd.f
+++ b/PARPACK/SRC/MPI/pcneupd.f
@@ -213,7 +213,7 @@ c             in upper triangular form.
 c     ctrsen  LAPACK routine that re-orders the Schur form.
 c     cunm2r  LAPACK routine that applies an orthogonal matrix in 
 c             factored form.
-c     pslamch ScaLAPACK routine that determines machine constants.
+c     pslamch10 ScaLAPACK routine that determines machine constants.
 c     ctrmm   Level 3 BLAS matrix times an upper triangular matrix.
 c     cgeru   Level 2 BLAS rank one update to a matrix.
 c     ccopy   Level 1 BLAS that copies one vector to another .
@@ -336,8 +336,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real
-     &           scnrm2,pslamch,slapy2
-      external   scnrm2,pslamch,slapy2
+     &           scnrm2,pslamch10,slapy2
+      external   scnrm2,pslamch10,slapy2
 c
       Complex
      &           cdotc
@@ -367,7 +367,7 @@ c     %---------------------------------%
 c     | Get machine dependent constant. |
 c     %---------------------------------%
 c
-      eps23 = pslamch(comm, 'Epsilon-Machine')
+      eps23 = pslamch10(comm, 'Epsilon-Machine')
       eps23 = eps23**(2.0 / 3.0)
 c
 c     %-------------------------------%

--- a/PARPACK/SRC/MPI/pslamch10.f
+++ b/PARPACK/SRC/MPI/pslamch10.f
@@ -1,4 +1,4 @@
-      REAL               FUNCTION PSLAMCH( ICTXT, CMACH )
+      REAL               FUNCTION PSLAMCH10( ICTXT, CMACH )
 *
       include "mpif.h"
 *  -- ScaLAPACK auxiliary routine (version 1.0) --
@@ -82,8 +82,8 @@
           TEMP = TEMP1
       END IF
 *
-      PSLAMCH = TEMP
+      PSLAMCH10 = TEMP
 *
-*     End of PSLAMCH
+*     End of PSLAMCH10
 *
       END

--- a/PARPACK/SRC/MPI/psnaitr.f
+++ b/PARPACK/SRC/MPI/psnaitr.f
@@ -142,7 +142,7 @@ c     arscnd   ARPACK utility routine for timing.
 c     psmout   Parallel ARPACK utility routine that prints matrices
 c     psvout   Parallel ARPACK utility routine that prints vectors.
 c     slabad   LAPACK routine that computes machine constants.
-c     pslamch  ScaLAPACK routine that determines machine constants.
+c     pslamch10  ScaLAPACK routine that determines machine constants.
 c     slascl   LAPACK routine for careful scaling of a matrix.
 c     slanhs   LAPACK routine that computes various norms of a matrix.
 c     sgemv    Level 2 BLAS routine for matrix vector multiplication.
@@ -298,8 +298,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real
-     &           sdot, psnorm2, slanhs, pslamch
-      external   sdot, psnorm2, slanhs, pslamch
+     &           sdot, psnorm2, slanhs, pslamch10
+      external   sdot, psnorm2, slanhs, pslamch10
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -326,10 +326,10 @@ c        | overflow should not occur.              |
 c        | REFERENCE: LAPACK subroutine slahqr     |
 c        %-----------------------------------------%
 c
-         unfl = pslamch(comm, 'safe minimum' )
+         unfl = pslamch10(comm, 'safe minimum' )
          ovfl = one / unfl
          call slabad( unfl, ovfl )
-         ulp = pslamch( comm, 'precision' )
+         ulp = pslamch10( comm, 'precision' )
          smlnum = unfl*( n / ulp )
          aitr_first = .false.
       end if

--- a/PARPACK/SRC/MPI/psnapps.f
+++ b/PARPACK/SRC/MPI/psnapps.f
@@ -102,7 +102,7 @@ c
 c\Routines called:
 c     slabad  LAPACK routine that computes machine constants.
 c     slacpy  LAPACK matrix copy routine.
-c     pslamch ScaLAPACK routine that determines machine constants.
+c     pslamch10 ScaLAPACK routine that determines machine constants.
 c     slanhs  LAPACK routine that computes various norms of a matrix.
 c     slapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     slarf   LAPACK routine that applies Householder reflection to
@@ -206,8 +206,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real
-     &           pslamch, slanhs, slapy2
-      external   pslamch, slanhs, slapy2
+     &           pslamch10, slanhs, slapy2
+      external   pslamch10, slanhs, slapy2
 c
 c     %----------------------%
 c     | Intrinsics Functions |
@@ -233,10 +233,10 @@ c        | overflow should not occur.                    |
 c        | REFERENCE: LAPACK subroutine slahqr           |
 c        %-----------------------------------------------%
 c
-         unfl = pslamch( comm, 'safe minimum' )
+         unfl = pslamch10( comm, 'safe minimum' )
          ovfl = one / unfl
          call slabad( unfl, ovfl )
-         ulp = pslamch( comm, 'precision' )
+         ulp = pslamch10( comm, 'precision' )
          smlnum = unfl*( n / ulp )
          apps_first = .false.
       end if

--- a/PARPACK/SRC/MPI/psnaup2.f
+++ b/PARPACK/SRC/MPI/psnaup2.f
@@ -148,7 +148,7 @@ c     pivout   Parallel ARPACK utility routine that prints integers.
 c     arscnd   ARPACK utility routine for timing.
 c     psmout   Parallel ARPACK utility routine that prints matrices
 c     psvout   ARPACK utility routine that prints vectors.
-c     pslamch  ScaLAPACK routine that determines machine constants.
+c     pslamch10  ScaLAPACK routine that determines machine constants.
 c     slapy2   LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     scopy    Level 1 BLAS that copies one vector to another .
 c     sdot     Level 1 BLAS that computes the scalar product of two vectors. 
@@ -262,8 +262,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real 
-     &           sdot, psnorm2, slapy2, pslamch
-      external   sdot, psnorm2, slapy2, pslamch
+     &           sdot, psnorm2, slapy2, pslamch10
+      external   sdot, psnorm2, slapy2, pslamch10
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -285,7 +285,7 @@ c        %-------------------------------------%
 c        | Get the machine dependent constant. |
 c        %-------------------------------------%
 c
-         eps23 = pslamch(comm, 'Epsilon-Machine')
+         eps23 = pslamch10(comm, 'Epsilon-Machine')
          eps23 = eps23**(2.0  / 3.0 )
 c
          nev0   = nev

--- a/PARPACK/SRC/MPI/psnaupd.f
+++ b/PARPACK/SRC/MPI/psnaupd.f
@@ -384,7 +384,7 @@ c              Arnoldi Iteration.
 c     pivout   Parallel ARPACK utility routine that prints integers.
 c     arscnd   ARPACK utility routine for timing.
 c     psvout   Parallel ARPACK utility routine that prints vectors.
-c     pslamch  ScaLAPACK routine that determines machine constants.
+c     pslamch10  ScaLAPACK routine that determines machine constants.
 c
 c\Author
 c     Danny Sorensen               Phuong Vu
@@ -476,8 +476,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real 
-     &           pslamch
-      external   pslamch
+     &           pslamch10
+      external   pslamch10
 c
 c     %-----------------------%
 c     | Executable Statements |
@@ -561,7 +561,7 @@ c        | Set default parameters |
 c        %------------------------%
 c
          if (nb .le. 0)	nb = 1
-         if (tol .le. zero)	tol = pslamch(comm, 'EpsMach')
+         if (tol .le. zero)	tol = pslamch10(comm, 'EpsMach')
 c
 c        %----------------------------------------------%
 c        | NP is the number of additional steps to      |

--- a/PARPACK/SRC/MPI/psneupd.f
+++ b/PARPACK/SRC/MPI/psneupd.f
@@ -238,7 +238,7 @@ c             a matrix.
 c     slacpy  LAPACK matrix copy routine.
 c     slahqr  LAPACK routine to compute the real Schur form of an
 c             upper Hessenberg matrix.
-c     pslamch ScaLAPACK routine that determines machine constants.
+c     pslamch10 ScaLAPACK routine that determines machine constants.
 c     slapy2  LAPACK routine to compute sqrt(x**2+y**2) carefully.
 c     slaset  LAPACK matrix initialization routine.
 c     sorm2r  LAPACK routine that applies an orthogonal matrix in 
@@ -388,8 +388,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real 
-     &           slapy2, snrm2, pslamch
-      external   slapy2, snrm2, pslamch
+     &           slapy2, snrm2, pslamch10
+      external   slapy2, snrm2, pslamch10
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -414,7 +414,7 @@ c     %---------------------------------%
 c     | Get machine dependent constant. |
 c     %---------------------------------%
 c
-      eps23 = pslamch(comm, 'Epsilon-Machine')
+      eps23 = pslamch10(comm, 'Epsilon-Machine')
       eps23 = eps23**(2.0  / 3.0 )
 c
 c     %--------------%

--- a/PARPACK/SRC/MPI/pssaitr.f
+++ b/PARPACK/SRC/MPI/pssaitr.f
@@ -139,7 +139,7 @@ c     psgetv0  Parallel ARPACK routine to generate the initial vector.
 c     pivout   Parallel ARPACK utility routine that prints integers.
 c     psmout   Parallel ARPACK utility routine that prints matrices.
 c     psvout   Parallel ARPACK utility routine that prints vectors.
-c     pslamch  ScaLAPACK routine that determines machine constants.
+c     pslamch10  ScaLAPACK routine that determines machine constants.
 c     slascl   LAPACK routine for careful scaling of a matrix.
 c     sgemv    Level 2 BLAS routine for matrix vector multiplication.
 c     saxpy    Level 1 BLAS that computes a vector triad.
@@ -291,8 +291,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real
-     &           sdot, psnorm2, pslamch
-      external   sdot, psnorm2, pslamch
+     &           sdot, psnorm2, pslamch10
+      external   sdot, psnorm2, pslamch10
 c
 c     %-----------------%
 c     | Data statements |
@@ -318,7 +318,7 @@ c        | safmin = safe minimum is such  |
 c        | that 1/sfmin does not overflow |
 c        %--------------------------------%
 c
-         safmin = pslamch(comm,'safmin')
+         safmin = pslamch10(comm,'safmin')
       end if
 c
       if (ido .eq. 0) then

--- a/PARPACK/SRC/MPI/pssapps.f
+++ b/PARPACK/SRC/MPI/pssapps.f
@@ -95,7 +95,7 @@ c\Routines called:
 c     pivout  Parallel ARPACK utility routine that prints integers. 
 c     arscnd  ARPACK utility routine for timing.
 c     psvout  Parallel ARPACK utility routine that prints vectors.
-c     pslamch ScaLAPACK routine that determines machine constants.
+c     pslamch10 ScaLAPACK routine that determines machine constants.
 c     slartg  LAPACK Givens rotation construction routine.
 c     slacpy  LAPACK matrix copy routine.
 c     slaset  LAPACK matrix initialization routine.
@@ -194,8 +194,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real
-     &           pslamch
-      external   pslamch
+     &           pslamch10
+      external   pslamch10
 c
 c     %----------------------%
 c     | Intrinsics Functions |
@@ -213,7 +213,7 @@ c     | Executable Statements |
 c     %-----------------------%
 c
       if (apps_first) then
-         epsmch = pslamch(comm, 'Epsilon-Machine')
+         epsmch = pslamch10(comm, 'Epsilon-Machine')
          apps_first = .false.
       end if
       itop = 1

--- a/PARPACK/SRC/MPI/pssaup2.f
+++ b/PARPACK/SRC/MPI/pssaup2.f
@@ -155,7 +155,7 @@ c              tridiagonal matrix using the implicit QL or QR method.
 c     pivout   Parallel ARPACK utility routine that prints integers.
 c     arscnd   ARPACK utility routine for timing.
 c     psvout   Parallel ARPACK utility routine that prints vectors.
-c     pslamch  ScaLAPACK routine that determines machine constants.
+c     pslamch10  ScaLAPACK routine that determines machine constants.
 c     scopy    Level 1 BLAS that copies one vector to another.
 c     sdot     Level 1 BLAS that computes the scalar product of two vectors.
 c     psnorm2  Parallel version of Level 1 BLAS that computes the norm of a vector.
@@ -263,8 +263,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real
-     &           sdot, psnorm2, pslamch
-      external   sdot, psnorm2, pslamch
+     &           sdot, psnorm2, pslamch10
+      external   sdot, psnorm2, pslamch10
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -290,7 +290,7 @@ c        %---------------------------------%
 c        | Set machine dependent constant. |
 c        %---------------------------------%
 c
-         eps23 = pslamch(comm, 'Epsilon-Machine')
+         eps23 = pslamch10(comm, 'Epsilon-Machine')
          eps23 = eps23**(2.0/3.0)
 c
 c        %-------------------------------------%

--- a/PARPACK/SRC/MPI/pssaupd.f
+++ b/PARPACK/SRC/MPI/pssaupd.f
@@ -386,7 +386,7 @@ c              variables.
 c     pivout   Parallel ARPACK utility routine that prints integers.
 c     arscnd   ARPACK utility routine for timing.
 c     psvout   Parallel ARPACK utility routine that prints vectors.
-c     pslamch  ScaLAPACK routine that determines machine constants.
+c     pslamch10  ScaLAPACK routine that determines machine constants.
 c
 c\Authors
 c     Kristi Maschhoff ( Parallel Code )
@@ -480,8 +480,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real 
-     &           pslamch
-      external   pslamch
+     &           pslamch10
+      external   pslamch10
 c
 c     %-----------------------%
 c     | Executable Statements |
@@ -571,7 +571,7 @@ c        | Set default parameters |
 c        %------------------------%
 c
          if (nb .le. 0) nb = 1
-         if (tol .le. zero) tol = pslamch(comm, 'EpsMach')
+         if (tol .le. zero) tol = pslamch10(comm, 'EpsMach')
 c
 c        %----------------------------------------------%
 c        | NP is the number of additional steps to      |

--- a/PARPACK/SRC/MPI/psseupd.f
+++ b/PARPACK/SRC/MPI/psseupd.f
@@ -191,7 +191,7 @@ c     psvout  Parallel ARPACK utility routine that prints vectors.
 c     sgeqr2  LAPACK routine that computes the QR factorization of
 c             a matrix.
 c     slacpy  LAPACK matrix copy routine.
-c     pslamch ScaLAPACK routine that determines machine constants.
+c     pslamch10 ScaLAPACK routine that determines machine constants.
 c     sorm2r  LAPACK routine that applies an orthogonal matrix in
 c             factored form.
 c     ssteqr  LAPACK routine that computes eigenvalues and eigenvectors
@@ -295,8 +295,8 @@ c     | External Functions |
 c     %--------------------%
 c
       Real
-     &           psnorm2, pslamch
-      external   psnorm2, pslamch
+     &           psnorm2, pslamch10
+      external   psnorm2, pslamch10
 c
 c     %---------------------%
 c     | Intrinsic Functions |
@@ -439,7 +439,7 @@ c     %---------------------------------%
 c     | Set machine dependent constant. |
 c     %---------------------------------%
 c
-      eps23 = pslamch(comm, 'Epsilon-Machine') 
+      eps23 = pslamch10(comm, 'Epsilon-Machine') 
       eps23 = eps23**(2.0 / 3.0)
 c
 c     %---------------------------------------%


### PR DESCRIPTION
fixes https://github.com/opencollab/arpack-ng/issues/50