### PR TITLE
TravisCI: kill libc++-dev.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
       - gfortran
       - gcc
       - g++
-      - libc++-dev
       - libblas-dev
       - liblapack-dev
       - libopenmpi-dev


### PR DESCRIPTION
kill useless dep (added when confused by cmake problem related to iso_c_binding)