### PR TITLE
parpack: running autotools tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ EXAMPLES/SYM/[sd]sdrv[123456]
 PARPACK/EXAMPLES/MPI/p[sd]ndrv[13]
 PARPACK/EXAMPLES/MPI/p[sd]sdrv1
 PARPACK/EXAMPLES/MPI/p[cz]ndrv1
+PARPACK/TESTS/MPI/icb_parpack_c
+PARPACK/TESTS/MPI/icb_parpack_cpp
+PARPACK/TESTS/MPI/issue46
 
 *.lib
 *.def

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,9 @@ script:
   - if [ "$BUILD" == "configure" ]; then make all ; fi
   - if [ "$BUILD" == "configure" ]; then make check ; fi
   - if [ "$BUILD" == "configure" ]; then make distcheck ; fi
-# - if [ "$BUILD" == "configure" ]; then ./configure --enable-mpi --enable-icb ; fi # TODO
-# - if [ "$BUILD" == "configure" ]; then make all ; fi
-# - if [ "$BUILD" == "configure" ]; then make check ; fi
+  - if [ "$BUILD" == "configure" ]; then ./configure --enable-mpi --enable-icb ; fi
+  - if [ "$BUILD" == "configure" ]; then make all ; fi
+  - if [ "$BUILD" == "configure" ]; then make check ; fi
   - if [ "$BUILD" == "configure" ]; then ./configure --enable-icb ; fi
   - if [ "$BUILD" == "configure" ]; then make all ; fi
   - if [ "$BUILD" == "configure" ]; then make check ; fi

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,6 @@ arpack-ng - 3.6.0
  * Add support for ISO_C_BINDING (Fortran std 2003) for PARPACK to improve portability (Fortran/C/C++).
    Example of   C/Fortran binding can be found in the PARPACK/TESTS/MPI/icb_parpack_c.c     file.
    Example of C++/Fortran binding can be found in the PARPACK/TESTS/MPI/icb_parpack_cpp.cpp file.
-   cmake test suite is OK. autotools test suite has not been finished (check the TODO file).
 
  [ Denis Davydov ]
  * Rename pslamch to pslamch10 to avoid symbol collision with Scalapack 2.0.2 in MPI context.

--- a/PARPACK/TESTS/MPI/Makefile.am
+++ b/PARPACK/TESTS/MPI/Makefile.am
@@ -5,9 +5,8 @@ SISS = issue46
 
 check_PROGRAMS = $(SISS)
 if ICB
-## TODO: add icb_parpack_c and icb_parpack_cpp tests in test suite
-#check_PROGRAMS += icb_parpack_c
-#check_PROGRAMS += icb_parpack_cpp
+check_PROGRAMS += icb_parpack_c
+check_PROGRAMS += icb_parpack_cpp
 endif
 
 EXTRA_DIST = debug.h stat.h
@@ -15,17 +14,13 @@ EXTRA_DIST = debug.h stat.h
 issue46_SOURCES= issue46.f
 
 if ICB
-## TODO: how use mpicc instead of gcc ?
-## TODO: how to run tests with 2 mpi procs ?
-#icb_parpack_c_SOURCES = icb_parpack_c.c
-#icb_parpack_c_LDADD = $(LDADD) $(MPI_C_LIBS)
-#icb_parpack_c_CFLAGS = -I$(top_builddir)
+icb_parpack_c_SOURCES = icb_parpack_c.c
+icb_parpack_c_LDADD = $(LDADD) $(MPI_C_LIBS)
+icb_parpack_c_CFLAGS = -I$(top_builddir)
 
-## TODO: how use mpicc instead of gcc ?
-## TODO: how to run tests with 2 mpi procs ?
-#icb_parpack_cpp_SOURCES = icb_parpack_cpp.cpp
-#icb_parpack_cpp_LDADD = $(LDADD) $(MPI_CXX_LIBS)
-#icb_parpack_cpp_CPPFLAGS = -I$(top_builddir)
+icb_parpack_cpp_SOURCES = icb_parpack_cpp.cpp
+icb_parpack_cpp_LDADD = $(LDADD) $(MPI_CXX_LIBS)
+icb_parpack_cpp_CPPFLAGS = -I$(top_builddir)
 endif
 
 TESTS = $(check_PROGRAMS)

--- a/TODO
+++ b/TODO
@@ -1,9 +1,3 @@
 * add a version somewhere to allow configure to detect it
-* add icb_parpack_c and icb_parpack_cpp tests in autotools test suite
-  check out TODO in PARPACK/TESTS/MPI/Makefile.am and .travis.yml
-  => uncomment "TODO lines" in PARPACK/TESTS/MPI/Makefile.am
-  => run: ./bootstrap; ./configure --enable-mpi --enable-icb; make all check
-  => problem is icb_parpack_c.c and icb_parpack_cpp.cpp do not link...
-     autotools gurus who could fix this will maybe find their way to a solution
-     in the HDF5 tarball (check m4/aclocal_fc.* and PAC_* macros)
-  => if this could be fixed: do not forget to uncomment TODO in .travis.yml
+* autotools: run PARPACK tests with "mpirun -n 2" (for now, they run
+  sequentially like "mpirun -n 1"): check PARPACK/TESTS/MPI/Makefile.am

--- a/configure.ac
+++ b/configure.ac
@@ -121,16 +121,22 @@ if test x"$enable_icb" != x"no"; then
   AC_CONFIG_FILES([arpack.h:arpack.h])
   AC_CONFIG_FILES([arpack.hpp:arpack.hpp])
   if test x"$enable_mpi" != x"no"; then
+    AC_LANG_PUSH([Fortran])
+    AX_MPI([], AC_MSG_ERROR([could not compile a Fortran MPI test program]))
+    FC=$MPIFC
+    AC_FC_WRAPPERS dnl set FCLIBS
+    AC_LANG_POP([Fortran])
+
     AC_CONFIG_FILES([parpack.h:parpack.h])
     AC_CONFIG_FILES([parpack.hpp:parpack.hpp])
     AC_LANG_PUSH([C])
     AX_MPI([], AC_MSG_ERROR([could not compile a C MPI test program]))
-    AC_SUBST([MPI_C_LIBS], [$MPILIBS])
+    AC_SUBST([MPI_C_LIBS], ["$MPILIBS $FCLIBS"])
     CC=$MPICC
     AC_LANG_POP([C])
     AC_LANG_PUSH([C++])
     AX_MPI([], AC_MSG_ERROR([could not compile a C++ MPI test program]))
-    AC_SUBST([MPI_CXX_LIBS], [$MPILIBS])
+    AC_SUBST([MPI_CXX_LIBS], ["$MPILIBS $FCLIBS"])
     CXX=$MPICXX
     AC_LANG_POP([C++])
   fi


### PR DESCRIPTION
note: ax_mpi must be ran twice (first run in --enable-mpi scope
is lost when entering --enable-icb scope).