### PR TITLE
autotools: run parpack tests with "mpirun -n 2".

### DIFF
--- a/PARPACK/TESTS/MPI/Makefile.am
+++ b/PARPACK/TESTS/MPI/Makefile.am
@@ -1,6 +1,10 @@
 F77 = $(MPIF77)
 LDADD = $(top_builddir)/PARPACK/SRC/MPI/libparpack$(LIBSUFFIX).la $(LAPACK_LIBS) $(BLAS_LIBS)
 
+# Run MPI tests with "mpirun -n 2"
+LOG_COMPILER = mpirun
+LOG_FLAGS = -n 2
+
 SISS = issue46
 
 check_PROGRAMS = $(SISS)

--- a/TODO
+++ b/TODO
@@ -1,3 +1,1 @@
 * add a version somewhere to allow configure to detect it
-* autotools: run PARPACK tests with "mpirun -n 2" (for now, they run
-  sequentially like "mpirun -n 1"): check PARPACK/TESTS/MPI/Makefile.am


### PR DESCRIPTION
Not 100% sure... But according to this : https://www.gnu.org/software/automake/manual/html_node/Parallel-Test-Harness.html, it should be the way to handle mpirun with autotools. Check tests logs.