### PR TITLE
Coverage by codecov via github.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,47 @@
+codecov:
+
+  branches: *
+
+  ci:
+
+    - travis-ci.org
+
+coverage:
+
+  range: 75..100
+
+  round: nearest
+
+  precision: 2
+
+  status:
+
+    project:
+
+      default:
+
+        enabled: yes
+
+        target: auto
+
+        if_not_found: success
+
+        if_ci_failed: error
+
+    patch:
+
+      default:
+
+        enabled: yes
+
+        target: 75%
+
+        if_not_found: success
+
+        if_ci_failed: error
+
+comment:
+
+  behavior: default
+
+  layout: "header, diff"

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,3 +73,9 @@ script:
   - if [ "$BUILD" == "configure" ]; then ./configure ; fi
   - if [ "$BUILD" == "configure" ]; then make all ; fi
   - if [ "$BUILD" == "configure" ]; then make check ; fi
+
+after_success:
+
+  # COVERAGE
+  - if [[ "$BUILD" == "cmake" ]]; then gcov -s ../SRC -s ../PARPACK/SRC/MPI CMakeFiles/arpack.dir/SRC/* CMakeFiles/parpack.dir/PARPACK/SRC/MPI/*; fi
+  - if [[ "$BUILD" == "cmake" ]]; then bash <(curl -s https://codecov.io/bash); fi


### PR DESCRIPTION
If you subscribe to codecov (free), you can have coverage on github push.
Check here : https://github.com/fghoussen/arpack-ng/commits/cov (click on green cross of 4fff365).