### PR TITLE
CMake: merge "make test" and "make check"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,39 +25,39 @@ script:
   - if [ "$BUILD" == "cmake" ]; then mkdir build ; fi
   - if [ "$BUILD" == "cmake" ]; then cd build ; fi
   - if [ "$BUILD" == "cmake" ]; then cmake -D EXAMPLES=ON -D MPI=ON  -D ICB=OFF .. ; fi
-  - if [ "$BUILD" == "cmake" ]; then make all check ; fi
+  - if [ "$BUILD" == "cmake" ]; then make all ; fi
   - if [ "$BUILD" == "cmake" ]; then make test ; fi
   - if [ "$BUILD" == "cmake" ]; then rm -fr * ; fi # Restart cmake from scratch.
   - if [ "$BUILD" == "cmake" ]; then cmake -D EXAMPLES=ON -D MPI=ON  -D ICB=ON  .. ; fi
-  - if [ "$BUILD" == "cmake" ]; then make all check ; fi
+  - if [ "$BUILD" == "cmake" ]; then make all ; fi
   - if [ "$BUILD" == "cmake" ]; then make test ; fi
   - if [ "$BUILD" == "cmake" ]; then rm -fr * ; fi # Restart cmake from scratch.
   - if [ "$BUILD" == "cmake" ]; then cmake -D EXAMPLES=ON -D MPI=OFF -D ICB=OFF .. ; fi
-  - if [ "$BUILD" == "cmake" ]; then make all check ; fi
+  - if [ "$BUILD" == "cmake" ]; then make all ; fi
   - if [ "$BUILD" == "cmake" ]; then make test ; fi
   - if [ "$BUILD" == "cmake" ]; then rm -fr * ; fi # Restart cmake from scratch.
   - if [ "$BUILD" == "cmake" ]; then cmake -D EXAMPLES=ON -D MPI=OFF -D ICB=ON  .. ; fi
-  - if [ "$BUILD" == "cmake" ]; then make all check ; fi
+  - if [ "$BUILD" == "cmake" ]; then make all ; fi
   - if [ "$BUILD" == "cmake" ]; then make test ; fi
   - if [ "$BUILD" == "cmake" ]; then rm -fr * ; fi # Restart cmake from scratch.
   - if [ "$BUILD" == "cmake" ]; then cmake -D BUILD_SHARED_LIBS=ON -D MPI=ON  -D ICB=OFF .. ; fi
-  - if [ "$BUILD" == "cmake" ]; then make all check ; fi
+  - if [ "$BUILD" == "cmake" ]; then make all ; fi
   - if [ "$BUILD" == "cmake" ]; then make test ; fi
   - if [ "$BUILD" == "cmake" ]; then rm -fr * ; fi # Restart cmake from scratch.
   - if [ "$BUILD" == "cmake" ]; then cmake -D BUILD_SHARED_LIBS=ON -D MPI=ON  -D ICB=ON  .. ; fi
-  - if [ "$BUILD" == "cmake" ]; then make all check ; fi
+  - if [ "$BUILD" == "cmake" ]; then make all ; fi
   - if [ "$BUILD" == "cmake" ]; then make test ; fi
   - if [ "$BUILD" == "cmake" ]; then rm -fr * ; fi # Restart cmake from scratch.
   - if [ "$BUILD" == "cmake" ]; then cmake -D BUILD_SHARED_LIBS=ON -D MPI=OFF -D ICB=OFF .. ; fi
-  - if [ "$BUILD" == "cmake" ]; then make all check ; fi
+  - if [ "$BUILD" == "cmake" ]; then make all ; fi
   - if [ "$BUILD" == "cmake" ]; then make test ; fi
   - if [ "$BUILD" == "cmake" ]; then rm -fr * ; fi # Restart cmake from scratch.
   - if [ "$BUILD" == "cmake" ]; then cmake -D BUILD_SHARED_LIBS=ON -D MPI=OFF -D ICB=ON  .. ; fi
-  - if [ "$BUILD" == "cmake" ]; then make all check ; fi
+  - if [ "$BUILD" == "cmake" ]; then make all ; fi
   - if [ "$BUILD" == "cmake" ]; then make test ; fi
   - if [ "$BUILD" == "cmake" ]; then rm -fr * ; fi # Restart cmake from scratch for code coverage
   - if [ "$BUILD" == "cmake" ]; then cmake -D EXAMPLES=ON -DCOVERALLS=ON -D MPI=ON -D ICB=ON ..  ; fi
-  - if [ "$BUILD" == "cmake" ]; then make all check test coveralls VERBOSE=1 ; fi
+  - if [ "$BUILD" == "cmake" ]; then make all test coveralls VERBOSE=1 ; fi
   # CONFIGURE
   - if [ "$BUILD" == "configure" ]; then ./bootstrap ; fi
   - if [ "$BUILD" == "configure" ]; then ./configure --enable-mpi ; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,14 +430,12 @@ endif()
 
 
 ############################
-# CHECK
+# TEST
 ############################
 
 enable_testing()
 
 set(CMAKE_CTEST_COMMAND ctest -V)
-
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Tests)
 
@@ -468,8 +466,6 @@ add_test(bug_58_double_tst Tests/bug_58_double)
 add_executable(bug_79_double_complex TESTS/bug_79_double_complex.f)
 target_link_libraries(bug_79_double_complex arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${EXTRA_LDLAGS})
 add_test(bug_79_double_complex_tst Tests/bug_79_double_complex)
-
-add_dependencies(check dnsimp_test bug_1315_single bug_1315_double bug_1323 bug_58_double bug_79_double_complex)
 
 if(MPI)
   add_executable(issue46 PARPACK/TESTS/MPI/issue46.f)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,33 +441,33 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Tests)
 
-add_executable(dnsimp_test EXCLUDE_FROM_ALL TESTS/dnsimp.f TESTS/mmio.f TESTS/debug.h)
+add_executable(dnsimp_test TESTS/dnsimp.f TESTS/mmio.f TESTS/debug.h)
 set_target_properties( dnsimp_test PROPERTIES OUTPUT_NAME  dnsimp )
 target_link_libraries(dnsimp_test arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${EXTRA_LDLAGS})
 add_custom_command(TARGET dnsimp_test POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/TESTS/testA.mtx testA.mtx
 )
-add_test(dnsimp_test Tests/dnsimp)
+add_test(dnsimp_tst Tests/dnsimp)
 
-add_executable(bug_1315_single EXCLUDE_FROM_ALL TESTS/bug_1315_single.c)
+add_executable(bug_1315_single TESTS/bug_1315_single.c)
 target_link_libraries(bug_1315_single arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${EXTRA_LDLAGS})
-add_test(bug_1315_single Tests/bug_1315_single)
+add_test(bug_1315_single_tst Tests/bug_1315_single)
 
-add_executable(bug_1315_double EXCLUDE_FROM_ALL TESTS/bug_1315_double.c)
+add_executable(bug_1315_double TESTS/bug_1315_double.c)
 target_link_libraries(bug_1315_double arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${EXTRA_LDLAGS})
-add_test(bug_1315_double Tests/bug_1315_double)
+add_test(bug_1315_double_tst Tests/bug_1315_double)
 
-add_executable(bug_1323 EXCLUDE_FROM_ALL TESTS/bug_1323.f)
+add_executable(bug_1323 TESTS/bug_1323.f)
 target_link_libraries(bug_1323 arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${EXTRA_LDLAGS})
-add_test(bug_1323 Tests/bug_1323)
+add_test(bug_1323_tst Tests/bug_1323)
 
-add_executable(bug_58_double EXCLUDE_FROM_ALL TESTS/bug_58_double.f)
+add_executable(bug_58_double TESTS/bug_58_double.f)
 target_link_libraries(bug_58_double arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${EXTRA_LDLAGS})
-add_test(bug_58_double Tests/bug_58_double)
+add_test(bug_58_double_tst Tests/bug_58_double)
 
-add_executable(bug_79_double_complex EXCLUDE_FROM_ALL TESTS/bug_79_double_complex.f)
+add_executable(bug_79_double_complex TESTS/bug_79_double_complex.f)
 target_link_libraries(bug_79_double_complex arpack ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${EXTRA_LDLAGS})
-add_test(bug_79_double_complex Tests/bug_79_double_complex)
+add_test(bug_79_double_complex_tst Tests/bug_79_double_complex)
 
 add_dependencies(check dnsimp_test bug_1315_single bug_1315_double bug_1323 bug_58_double bug_79_double_complex)
 


### PR DESCRIPTION
Took 10 minutes to make things more like the "cmake way" : get all tests OK with "make test".
So you may drop "make check" (which is more the autotools way) as it's integrated in "make test".
Not sure you want that... If not, kill it !