### PR TITLE
Add includedir to pkg-config file

### DIFF
--- a/arpack.pc.in
+++ b/arpack.pc.in
@@ -1,6 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
+includedir=@includedir@
 
 Name: @PACKAGE_NAME@
 Description: Collection of Fortran77 subroutines designed to solve large scale eigenvalue problems


### PR DESCRIPTION
Without this line, pkg-config 0.29.2 refuses to parse the arpack.pc file:

# pkg-config --libs arpack
Variable 'includedir' not defined in '/usr/lib/pkgconfig/arpack.pc'