### PR TITLE
C++11 (for ICB): do NOT use hard-coded gnu++11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,13 @@ addons:
       - gfortran
       - gcc
       - g++
+      - openmpi-bin
+      - libopenmpi-dev
+      - cmake
+      - automake
+      - autoconf
       - libblas-dev
       - liblapack-dev
-      - libopenmpi-dev
-      - openmpi-bin
 
 env:
   - BUILD=cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ endfunction(pexamples)
 if (ICB)
     enable_language(C CXX) # For testing binding with c/c++.
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+    set(CMAKE_CXX_STANDARD 11) # OK, since cmake-3.1 only.
 
     file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/PROG_ICB.f90
          "

--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,7 @@ if test x"$enable_icb" != x"no"; then
     AC_LANG_PUSH([C++])
     AX_MPI([], AC_MSG_ERROR([could not compile a C++ MPI test program]))
     AC_SUBST([MPI_CXX_LIBS], ["$MPILIBS $FCLIBS"])
+    CXX=$MPICXX
     AC_LANG_POP([C++])
 
     AC_LANG_PUSH([C])

--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,7 @@ if test x"$enable_icb" != x"no"; then
 
   AC_PROG_CC
   AC_PROG_CXX
-  AX_CXX_COMPILE_STDCXX(11, ext)
+  AX_CXX_COMPILE_STDCXX(11)
   AM_CONDITIONAL([ICB], [true])
   AC_CONFIG_FILES([arpack.h:arpack.h])
   AC_CONFIG_FILES([arpack.hpp:arpack.hpp])
@@ -159,7 +159,6 @@ if test x"$enable_icb" != x"no"; then
     AC_LANG_PUSH([C++])
     AX_MPI([], AC_MSG_ERROR([could not compile a C++ MPI test program]))
     AC_SUBST([MPI_CXX_LIBS], ["$MPILIBS $FCLIBS"])
-    CXX="$MPICXX -std=gnu++11"
     AC_LANG_POP([C++])
 
     AC_LANG_PUSH([C])

--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,6 @@ if test x"$enable_icb" != x"no"; then
 
   AC_PROG_CC
   AC_PROG_CXX
-  AX_CXX_COMPILE_STDCXX(11)
   AM_CONDITIONAL([ICB], [true])
   AC_CONFIG_FILES([arpack.h:arpack.h])
   AC_CONFIG_FILES([arpack.hpp:arpack.hpp])
@@ -179,6 +178,7 @@ if test x"$enable_icb" != x"no"; then
                   )
     AC_LANG_POP([C])
   fi
+  AX_CXX_COMPILE_STDCXX(11)
 fi
 
 dnl Add support for debuging arpack


### PR DESCRIPTION
Hard-coded gnu++11 may break on specific archis (armel, ppc64el, ...).