### PR TITLE
Add configuration summary.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,9 +2,10 @@ arpack-ng - 3.6.2
 
  * Remove all trailing whitespaces
 
-[ Franck Houssen ]
+ [ Franck Houssen ]
  * Install: move headers into a dedicated directory (local/include/arpack).
    (Closes #126)
+ * Add configuration summary.
 
  -- Sylvestre Ledru <sylvestre@debian.org> Sat, 23 Jun 2018 14:56:54 +0200
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,3 +571,60 @@ if (COVERALLS)
         "${PROJECT_SOURCE_DIR}/cmake/") # (Optional) Alternate project cmake module path.
 endif()
 
+function(libsummary title include libraries)
+    message("   -- ${title}:")
+    foreach(inc ${include})
+        message("      -- compile: ${inc}")
+    endforeach()
+    foreach(lib ${libraries})
+        message("      -- link:    ${lib}")
+    endforeach()
+endfunction(libsummary)
+
+function(cprsummary title compiler debug_flags minsizerel_flags release_flags relwithdebinfo_flags more_flags)
+    message("   -- ${title}:      ${compiler}")
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR "${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
+        message("   -- ${title}FLAGS: ${debug_flags} ${more_flags}")
+    endif()
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel" OR "${CMAKE_BUILD_TYPE}" STREQUAL "MINSIZEREL")
+        message("   -- ${title}FLAGS: ${minsizerel_flags} ${more_flags}")
+    endif()
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Release" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
+        message("   -- ${title}FLAGS: ${release_flags} ${more_flags}")
+    endif()
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RELWITHDEBINFO")
+        message("   -- ${title}FLAGS: ${relwithdebinfo_flags} ${more_flags}")
+    endif()
+endfunction(cprsummary)
+
+message("-- Configuration summary for arpack-ng-${arpack_ng_VERSION}:")
+message("   -- prefix: ${CMAKE_INSTALL_PREFIX}")
+cprsummary("FC" "${CMAKE_Fortran_COMPILER}"
+                "${CMAKE_Fortran_FLAGS_DEBUG}"
+                "${CMAKE_Fortran_FLAGS_MINSIZEREL}"
+                "${CMAKE_Fortran_FLAGS_RELEASE}"
+                "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}"
+                "${CMAKE_Fortran_FLAGS}")
+if (ICB)
+    cprsummary("CC" "${CMAKE_C_COMPILER}"
+                    "${CMAKE_C_FLAGS_DEBUG}"
+                    "${CMAKE_C_FLAGS_MINSIZEREL}"
+                    "${CMAKE_C_FLAGS_RELEASE}"
+                    "${CMAKE_C_FLAGS_RELWITHDEBINFO}"
+                    "${CMAKE_C_FLAGS}")
+    cprsummary("CXX" "${CMAKE_CXX_COMPILER}"
+                     "${CMAKE_CXX_FLAGS_DEBUG}"
+                     "${CMAKE_CXX_FLAGS_MINSIZEREL}"
+                     "${CMAKE_CXX_FLAGS_RELEASE}"
+                     "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}"
+                     "${CMAKE_CXX_FLAGS}")
+endif()
+if (MPI)
+    libsummary("MPIFC" "${MPI_Fortran_INCLUDE_PATH}" "${MPI_Fortran_LIBRARIES}")
+    if (ICB)
+        libsummary("MPICC" "${MPI_C_INCLUDE_PATH}" "${MPI_C_LIBRARIES}")
+        libsummary("MPICXX" "${MPI_CXX_INCLUDE_PATH}" "${MPI_CXX_LIBRARIES}")
+    endif()
+endif()
+libsummary("BLAS" "" "${BLAS_LIBRARIES}")
+libsummary("LAPACK" "" "${LAPACK_LIBRARIES}")

--- a/configure.ac
+++ b/configure.ac
@@ -220,3 +220,21 @@ AC_CONFIG_FILES([
 	PARPACK/EXAMPLES/BLACS/Makefile
 ])
 AC_OUTPUT
+
+AC_MSG_RESULT([
+--------------------------------------------------
+Configuration summary for $PACKAGE_NAME ($VERSION)
+--------------------------------------------------
+Installation prefix : $prefix
+FC                  : $FC
+FCFLAGS             : $FCFLAGS
+CC                  : $CC
+CFLAGS              : $CFLAGS
+CXX                 : $CXX
+CXXFLAGS            : $CXXFLAGS
+BLAS                : $BLAS_LIBS
+LAPACK              : $LAPACK_LIBS
+--------------------------------------------------
+Configuration OK
+--------------------------------------------------
+])


### PR DESCRIPTION
I usually add messages of that kind for all packages I handle: I do believe it makes things clear (trust what you got) and enable to avoid/detect problems (like the ones you have currently on armel, ppc64el, ...)

You may not want that...