### PR TITLE
Fix initialization of debug variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,8 +179,8 @@ file(GLOB arpacksrc_STAT_SRCS ${arpack_SOURCE_DIR}/SRC/*.f)
 set(arpacksrc_ICB "")
 set(parpacksrc_ICB "")
 if(ICB)
-  file(GLOB arpacksrc_ICB SRC/icba*.f90 debug_init.f90 debug_icb.f90 stat_icb.f90)
-  file(GLOB parpacksrc_ICB PARPACK/SRC/MPI/icbp*.f90 debug_init.f90 debug_icb.f90 stat_icb.f90)
+  file(GLOB arpacksrc_ICB SRC/icba*.f90 debug_init.f debug_icb.f90 stat_icb.f90)
+  file(GLOB parpacksrc_ICB PARPACK/SRC/MPI/icbp*.f90 debug_init.f debug_icb.f90 stat_icb.f90)
 endif()
 
 set(arpackutil_STAT_SRCS

--- a/PARPACK/SRC/MPI/Makefile.am
+++ b/PARPACK/SRC/MPI/Makefile.am
@@ -34,7 +34,7 @@ libparpack@LIBSUFFIX@_noopt_la_FFLAGS = -O0
 
 lib_LTLIBRARIES = libparpack@LIBSUFFIX@.la
 libparpack@LIBSUFFIX@_la_SOURCES = $(PSRC) $(SSRC) $(DSRC) $(CSRC) $(ZSRC)
-libparpack@LIBSUFFIX@_la_SOURCES += $(top_builddir)/debug_init.f90
+libparpack@LIBSUFFIX@_la_SOURCES += $(top_builddir)/debug_init.f
 if ICB
 libparpack@LIBSUFFIX@_la_SOURCES += $(top_builddir)/debug_icb.f90
 libparpack@LIBSUFFIX@_la_SOURCES += $(top_builddir)/stat_icb.f90

--- a/SRC/Makefile.am
+++ b/SRC/Makefile.am
@@ -25,7 +25,7 @@ EXTRA_DIST = debug.h stat.h version.h
 
 lib_LTLIBRARIES = libarpack@LIBSUFFIX@.la
 libarpack@LIBSUFFIX@_la_SOURCES = $(SSRC) $(DSRC) $(CSRC) $(ZSRC)
-libarpack@LIBSUFFIX@_la_SOURCES += $(top_builddir)/debug_init.f90
+libarpack@LIBSUFFIX@_la_SOURCES += $(top_builddir)/debug_init.f
 if ICB
 libarpack@LIBSUFFIX@_la_SOURCES += $(top_builddir)/debug_icb.f90
 libarpack@LIBSUFFIX@_la_SOURCES += $(top_builddir)/stat_icb.f90

--- a/debug_init.f
+++ b/debug_init.f
@@ -1,0 +1,14 @@
+c Initialisation of the debug common block to "no debug".
+      block data debug_init
+      common /debug/ logfil, ndigit, mgetv0,
+     &     msaupd, msaup2, msaitr, mseigt, msapps, msgets, mseupd,
+     &     mnaupd, mnaup2, mnaitr, mneigh, mnapps, mngets, mneupd,
+     &     mcaupd, mcaup2, mcaitr, mceigh, mcapps, mcgets, mceupd
+      data logfil, ndigit, mgetv0,
+     &     msaupd, msaup2, msaitr, mseigt, msapps, msgets, mseupd,
+     &     mnaupd, mnaup2, mnaitr, mneigh, mnapps, mngets, mneupd,
+     &     mcaupd, mcaup2, mcaitr, mceigh, mcapps, mcgets, mceupd
+     &     / 6, -3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     &     0, 0, 0, 0, 0, 0 /
+      end
+


### PR DESCRIPTION
Replaces `debug_init.f90` with `debug_init.f`.
Fixes https://github.com/opencollab/arpack-ng/issues/144

MPI version is untested.

