### PR TITLE
[BUG FIX] howmny is defined as character*1 in pdseupd subroutine.

### DIFF
--- a/PARPACK/TESTS/MPI/issue46.f
+++ b/PARPACK/TESTS/MPI/issue46.f
@@ -255,7 +255,7 @@ c        %-------------------------------------------%
 c
          rvec = .true.
 c
-         call pdseupd ( comm, rvec, 'All', select,
+         call pdseupd ( comm, rvec, 'A', select,
      &        d, v, ldv, sigma,
      &        bmat, nloc, which, nev, tol, resid, ncv, v, ldv,
      &        iparam, ipntr, workd, workl, lworkl, ierr )


### PR DESCRIPTION
Cosmetic bug ("safer" way to get same thing).