### PR TITLE
[BUG FIX] When using *zneupd, sigma is complex.

### DIFF
--- a/PARPACK/TESTS/MPI/icb_parpack_c.c
+++ b/PARPACK/TESTS/MPI/icb_parpack_c.c
@@ -120,7 +120,7 @@ int zn() {
   int select[ncv];
   double _Complex z[(N+1)*(nev+1)];
   BLASINT ldz = N+1;
-  double sigma=0;
+  double _Complex sigma=0. + I*0.;
   int k;
   for (k=0; k < 3*N; ++k )
     workd[k] = 0. + I * 0.;

--- a/PARPACK/TESTS/MPI/icb_parpack_cpp.cpp
+++ b/PARPACK/TESTS/MPI/icb_parpack_cpp.cpp
@@ -113,7 +113,7 @@ void complex_symmetric_runner() {
 
   float tol = 0.0f;
   bool rvec = true;
-  float sigma = 0.0f;
+  std::complex<float> sigma(0.0f, 0.0f);
 
   std::vector<std::complex<float>> resid(N);
   std::vector<std::complex<float>> V(ncv * N);

--- a/TESTS/icb_arpack_c.c
+++ b/TESTS/icb_arpack_c.c
@@ -116,7 +116,7 @@ int zn() {
   int select[ncv];
   double _Complex z[(N+1)*(nev+1)];
   BLASINT ldz = N+1;
-  double sigma=0;
+  double _Complex sigma=0. + I*0.;
   int k;
   for (k=0; k < 3*N; ++k )
     workd[k] = 0;

--- a/TESTS/icb_arpack_cpp.cpp
+++ b/TESTS/icb_arpack_cpp.cpp
@@ -120,7 +120,7 @@ void complex_symmetric_runner() {
   BLASINT const lworkl = 3 * (ncv * ncv) + 6 * ncv;
 
   Real const tol = 0.0;
-  Real const sigma = 0.0;
+  std::complex<Real> const sigma(0.0, 0.0);
 
   bool const rvec = true;
 


### PR DESCRIPTION
Cosmetic bug ("better" way to get same thing - without this, sigma which
is used as an input, is implicitely converted from real to complex. Same
thing for the callee, but more "logical" for the caller).