### PR TITLE
Removed unnecessary export

### DIFF
--- a/VISUAL_STUDIO/arpack-ng_exports.def
+++ b/VISUAL_STUDIO/arpack-ng_exports.def
@@ -5,7 +5,6 @@ EXPORTS
 	cmout_
 	cvout_
 	dgetv0_
-	dlaqrb_
 	dmout_
 	dnaitr_
 	dnapps_


### PR DESCRIPTION
Fix for issue #227

After deleting line from with dlaqrb_ in VISUAL_STUDIO/arpack-ng_exports.def solution builds successfully on Windows using Microsoft Visual Studio Community 2017 (Version 15.9.17) with Intel Visual Fortran Compiler 19.0.0.117.