### PR TITLE
?vout expects a vector, so make sure to pass a vector

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,9 @@ arpack-ng - 3.8.0
 [ Kyle Guinn ]
  * [BUG FIX]: fix 'eval: Syntax error: "(" unexpected' error at build time.
 
+[ David Schwörer ]
+ * [BUG FIX] port to gcc 10
+
  -- Sylvestre Ledru <sylvestre@debian.org> Mon, 1 April 2019 16:24:00 +0100
 
 arpack-ng - 3.7.0

--- a/CHANGES
+++ b/CHANGES
@@ -21,7 +21,7 @@ arpack-ng - 3.8.0
  * [BUG FIX]: fix 'eval: Syntax error: "(" unexpected' error at build time.
 
 [ David Schwörer ]
- * [BUG FIX] port to gcc 10
+ * Support of gfortran 10
 
  -- Sylvestre Ledru <sylvestre@debian.org> Mon, 1 April 2019 16:24:00 +0100
 

--- a/SRC/cgetv0.f
+++ b/SRC/cgetv0.f
@@ -361,9 +361,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call svout (logfil, 1, rnorm0, ndigit,
+          call svout (logfil, 1, [rnorm0], ndigit,
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call svout (logfil, 1, rnorm, ndigit,
+          call svout (logfil, 1, [rnorm], ndigit,
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -394,7 +394,7 @@ c
    50 continue
 c
       if (msglvl .gt. 0) then
-         call svout (logfil, 1, rnorm, ndigit,
+         call svout (logfil, 1, [rnorm], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 2) then

--- a/SRC/cnaitr.f
+++ b/SRC/cnaitr.f
@@ -378,9 +378,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call svout (logfil, 1, rnorm, ndigit,
+            call svout (logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
 c
@@ -400,7 +400,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c
@@ -729,7 +729,7 @@ c
          end if
 c
          if (msglvl .gt. 0 .and. iter .gt. 0 ) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 rtemp(1) = rnorm

--- a/SRC/cnapps.f
+++ b/SRC/cnapps.f
@@ -268,9 +268,9 @@ c
          sigma = shift(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, jj, ndigit,
+            call ivout (logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call cvout (logfil, 1, sigma, ndigit,
+            call cvout (logfil, 1, [sigma], ndigit,
      &               '_napps: Value of the shift ')
          end if
 c
@@ -291,9 +291,9 @@ c
             if ( abs(real(h(i+1,i)))
      &           .le. max(ulp*tst1, smlnum) )  then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit,
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit,
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
                   call cvout (logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
@@ -307,9 +307,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, istart, ndigit,
+             call ivout (logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, iend, ndigit,
+             call ivout (logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -485,7 +485,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call cvout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, kev, ndigit,
+         call ivout (logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call cmout (logfil, kev, kev, h, ldh, ndigit,

--- a/SRC/cnaup2.f
+++ b/SRC/cnaup2.f
@@ -389,7 +389,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit,
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c
@@ -402,9 +402,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit,
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -430,7 +430,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call svout (logfil, 1, rnorm, ndigit,
+            call svout (logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c
@@ -658,7 +658,7 @@ c
          end if
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit,
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -698,7 +698,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call cvout (logfil, np, ritz, ndigit,
      &                  '_naup2: values of the shifts')
@@ -762,7 +762,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call svout (logfil, 1, rnorm, ndigit,
+            call svout (logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call cmout (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/SRC/cnaupd.f
+++ b/SRC/cnaupd.f
@@ -601,9 +601,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call cvout (logfil, np, workl(ritz), ndigit,
      &               '_naupd: The final Ritz values')

--- a/SRC/cneupd.f
+++ b/SRC/cneupd.f
@@ -536,9 +536,9 @@ c        | caused by incorrect passing of the dnaupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, numcnv, ndigit,
+             call ivout(logfil, 1, [numcnv], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if
 c

--- a/SRC/cngets.f
+++ b/SRC/cngets.f
@@ -161,8 +161,8 @@ c
       tcgets = tcgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_ngets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_ngets: NP is')
          call cvout (logfil, kev+np, ritz, ndigit,
      &        '_ngets: Eigenvalues of current H matrix ')
          call cvout (logfil, kev+np, bounds, ndigit,

--- a/SRC/dgetv0.f
+++ b/SRC/dgetv0.f
@@ -366,9 +366,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call dvout (logfil, 1, rnorm0, ndigit,
+          call dvout (logfil, 1, [rnorm0], ndigit,
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call dvout (logfil, 1, rnorm, ndigit,
+          call dvout (logfil, 1, [rnorm], ndigit,
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -399,7 +399,7 @@ c
    50 continue
 c
       if (msglvl .gt. 0) then
-         call dvout (logfil, 1, rnorm, ndigit,
+         call dvout (logfil, 1, [rnorm], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 3) then

--- a/SRC/dnaitr.f
+++ b/SRC/dnaitr.f
@@ -371,9 +371,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call dvout (logfil, 1, rnorm, ndigit,
+            call dvout (logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
 c
@@ -393,7 +393,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c
@@ -721,7 +721,7 @@ c
          end if
 c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/SRC/dnapps.f
+++ b/SRC/dnapps.f
@@ -266,11 +266,11 @@ c
          sigmai = shifti(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, jj, ndigit,
+            call ivout (logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call dvout (logfil, 1, sigmar, ndigit,
+            call dvout (logfil, 1, [sigmar], ndigit,
      &               '_napps: The real part of the shift ')
-            call dvout (logfil, 1, sigmai, ndigit,
+            call dvout (logfil, 1, [sigmai], ndigit,
      &               '_napps: The imaginary part of the shift ')
          end if
 c
@@ -335,9 +335,9 @@ c
      &         tst1 = dlanhs( '1', kplusp-jj+1, h, ldh, workl )
             if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit,
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit,
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
                   call dvout (logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
@@ -351,9 +351,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, istart, ndigit,
+             call ivout (logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, iend, ndigit,
+             call ivout (logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -627,7 +627,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call dvout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, kev, ndigit,
+         call ivout (logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call dmout (logfil, kev, kev, h, ldh, ndigit,

--- a/SRC/dnaup2.f
+++ b/SRC/dnaup2.f
@@ -388,7 +388,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit,
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c
@@ -401,9 +401,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit,
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -435,7 +435,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call dvout  (logfil, 1, rnorm, ndigit,
+            call dvout  (logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c
@@ -689,7 +689,7 @@ c
          end if
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit,
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -741,7 +741,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call dvout  (logfil, np, ritzr, ndigit,
      &                  '_naup2: Real part of the shifts')
@@ -807,7 +807,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call dvout  (logfil, 1, rnorm, ndigit,
+            call dvout  (logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call dmout  (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/SRC/dnaupd.f
+++ b/SRC/dnaupd.f
@@ -628,9 +628,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call dvout  (logfil, np, workl(ritzr), ndigit,
      &               '_naupd: Real part of the final Ritz values')

--- a/SRC/dneupd.f
+++ b/SRC/dneupd.f
@@ -601,9 +601,9 @@ c        | caused by incorrect passing of the dnaupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, numcnv, ndigit,
+             call ivout(logfil, 1, [numcnv], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if
 c

--- a/SRC/dngets.f
+++ b/SRC/dngets.f
@@ -212,8 +212,8 @@ c
       tngets = tngets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_ngets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_ngets: NP is')
          call dvout (logfil, kev+np, ritzr, ndigit,
      &        '_ngets: Eigenvalues of current H matrix -- real part')
          call dvout (logfil, kev+np, ritzi, ndigit,

--- a/SRC/dsaitr.f
+++ b/SRC/dsaitr.f
@@ -364,9 +364,9 @@ c
  1000 continue
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_saitr: generating Arnoldi vector no.')
-            call dvout (logfil, 1, rnorm, ndigit,
+            call dvout (logfil, 1, [rnorm], ndigit,
      &                  '_saitr: B-norm of the current residual =')
          end if
 c
@@ -384,7 +384,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_saitr: ****** restart at step ******')
             end if
 c
@@ -735,7 +735,7 @@ c
          end if
 c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_saitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/SRC/dsapps.f
+++ b/SRC/dsapps.f
@@ -261,9 +261,9 @@ c
             big   = abs(h(i,2)) + abs(h(i+1,2))
             if (h(i+1,1) .le. epsmch*big) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit,
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_sapps: deflation at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit,
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_sapps: occurred before shift number.')
                   call dvout (logfil, 1, h(i+1,1), ndigit,
      &                 '_sapps: the corresponding off diagonal element')
@@ -432,7 +432,7 @@ c
          big   = abs(h(i,2)) + abs(h(i+1,2))
          if (h(i+1,1) .le. epsmch*big) then
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, i, ndigit,
+               call ivout (logfil, 1, [i], ndigit,
      &              '_sapps: deflation at row/column no.')
                call dvout (logfil, 1, h(i+1,1), ndigit,
      &              '_sapps: the corresponding off diagonal element')

--- a/SRC/dsaup2.f
+++ b/SRC/dsaup2.f
@@ -402,13 +402,13 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit,
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_saup2: **** Start of major iteration number ****')
          end if
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit,
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_saup2: The length of the current Lanczos factorization')
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &           '_saup2: Extend the Lanczos factorization by')
          end if
 c
@@ -446,7 +446,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call dvout (logfil, 1, rnorm, ndigit,
+            call dvout (logfil, 1, [rnorm], ndigit,
      &           '_saup2: Current B-norm of residual for factorization')
          end if
 c
@@ -695,7 +695,7 @@ c
          end if
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit,
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_saup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -743,7 +743,7 @@ c
          if (ishift .eq. 0) call dcopy (np, workl, 1, ritz, 1)
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_saup2: The number of shifts to apply ')
             call dvout (logfil, np, workl, ndigit,
      &                  '_saup2: shifts selected')
@@ -810,7 +810,7 @@ c
   130    continue
 c
          if (msglvl .gt. 2) then
-            call dvout (logfil, 1, rnorm, ndigit,
+            call dvout (logfil, 1, [rnorm], ndigit,
      &      '_saup2: B-norm of residual for NEV factorization')
             call dvout (logfil, nev, h(1,2), ndigit,
      &           '_saup2: main diagonal of compressed H matrix')

--- a/SRC/dsaupd.f
+++ b/SRC/dsaupd.f
@@ -628,9 +628,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_saupd: number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_saupd: number of "converged" Ritz values')
          call dvout  (logfil, np, workl(Ritz), ndigit,
      &               '_saupd: final Ritz values')

--- a/SRC/dseupd.f
+++ b/SRC/dseupd.f
@@ -513,9 +513,9 @@ c        | caused by incorrect passing of the _saupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, numcnv, ndigit,
+             call ivout(logfil, 1, [numcnv], ndigit,
      &            '_seupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_seupd: Number of "converged" eigenvalues')
          end if
 c

--- a/SRC/dsgets.f
+++ b/SRC/dsgets.f
@@ -202,8 +202,8 @@ c
       tsgets = tsgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_sgets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_sgets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_sgets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_sgets: NP is')
          call dvout (logfil, kev+np, ritz, ndigit,
      &        '_sgets: Eigenvalues of current H matrix')
          call dvout (logfil, kev+np, bounds, ndigit,

--- a/SRC/sgetv0.f
+++ b/SRC/sgetv0.f
@@ -366,9 +366,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call svout (logfil, 1, rnorm0, ndigit,
+          call svout (logfil, 1, [rnorm0], ndigit,
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call svout (logfil, 1, rnorm, ndigit,
+          call svout (logfil, 1, [rnorm], ndigit,
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -399,7 +399,7 @@ c
    50 continue
 c
       if (msglvl .gt. 0) then
-         call svout (logfil, 1, rnorm, ndigit,
+         call svout (logfil, 1, [rnorm], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 3) then

--- a/SRC/snaitr.f
+++ b/SRC/snaitr.f
@@ -371,9 +371,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call svout (logfil, 1, rnorm, ndigit,
+            call svout (logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
 c
@@ -393,7 +393,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c
@@ -721,7 +721,7 @@ c
          end if
 c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/SRC/snapps.f
+++ b/SRC/snapps.f
@@ -266,11 +266,11 @@ c
          sigmai = shifti(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, jj, ndigit,
+            call ivout (logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call svout (logfil, 1, sigmar, ndigit,
+            call svout (logfil, 1, [sigmar], ndigit,
      &               '_napps: The real part of the shift ')
-            call svout (logfil, 1, sigmai, ndigit,
+            call svout (logfil, 1, [sigmai], ndigit,
      &               '_napps: The imaginary part of the shift ')
          end if
 c
@@ -335,9 +335,9 @@ c
      &         tst1 = slanhs( '1', kplusp-jj+1, h, ldh, workl )
             if( abs( h( i+1,i ) ).le.max( ulp*tst1, smlnum ) ) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit,
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit,
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
                   call svout (logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
@@ -351,9 +351,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, istart, ndigit,
+             call ivout (logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, iend, ndigit,
+             call ivout (logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -625,7 +625,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call svout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, kev, ndigit,
+         call ivout (logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call smout (logfil, kev, kev, h, ldh, ndigit,

--- a/SRC/snaup2.f
+++ b/SRC/snaup2.f
@@ -388,7 +388,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit,
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c
@@ -401,9 +401,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit,
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -435,7 +435,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call svout (logfil, 1, rnorm, ndigit,
+            call svout (logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c
@@ -690,7 +690,7 @@ c
          end if
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit,
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -742,7 +742,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call svout (logfil, np, ritzr, ndigit,
      &                  '_naup2: Real part of the shifts')
@@ -808,7 +808,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call svout (logfil, 1, rnorm, ndigit,
+            call svout (logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call smout (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/SRC/snaupd.f
+++ b/SRC/snaupd.f
@@ -628,9 +628,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call svout (logfil, np, workl(ritzr), ndigit,
      &               '_naupd: Real part of the final Ritz values')

--- a/SRC/sneupd.f
+++ b/SRC/sneupd.f
@@ -601,9 +601,9 @@ c        | caused by incorrect passing of the dnaupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, numcnv, ndigit,
+             call ivout(logfil, 1, [numcnv], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if
 c

--- a/SRC/sngets.f
+++ b/SRC/sngets.f
@@ -212,8 +212,8 @@ c
       tngets = tngets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_ngets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_ngets: NP is')
          call svout (logfil, kev+np, ritzr, ndigit,
      &        '_ngets: Eigenvalues of current H matrix -- real part')
          call svout (logfil, kev+np, ritzi, ndigit,

--- a/SRC/ssaitr.f
+++ b/SRC/ssaitr.f
@@ -364,9 +364,9 @@ c
  1000 continue
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_saitr: generating Arnoldi vector no.')
-            call svout (logfil, 1, rnorm, ndigit,
+            call svout (logfil, 1, [rnorm], ndigit,
      &                  '_saitr: B-norm of the current residual =')
          end if
 c
@@ -384,7 +384,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_saitr: ****** restart at step ******')
             end if
 c
@@ -735,7 +735,7 @@ c
          end if
 c
          if (msglvl .gt. 0 .and. iter .gt. 0) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_saitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 xtemp(1) = rnorm

--- a/SRC/ssapps.f
+++ b/SRC/ssapps.f
@@ -261,9 +261,9 @@ c
             big   = abs(h(i,2)) + abs(h(i+1,2))
             if (h(i+1,1) .le. epsmch*big) then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit,
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_sapps: deflation at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit,
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_sapps: occurred before shift number.')
                   call svout (logfil, 1, h(i+1,1), ndigit,
      &                 '_sapps: the corresponding off diagonal element')
@@ -432,7 +432,7 @@ c
          big   = abs(h(i,2)) + abs(h(i+1,2))
          if (h(i+1,1) .le. epsmch*big) then
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, i, ndigit,
+               call ivout (logfil, 1, [i], ndigit,
      &              '_sapps: deflation at row/column no.')
                call svout (logfil, 1, h(i+1,1), ndigit,
      &              '_sapps: the corresponding off diagonal element')

--- a/SRC/ssaup2.f
+++ b/SRC/ssaup2.f
@@ -402,13 +402,13 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit,
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_saup2: **** Start of major iteration number ****')
          end if
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit,
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_saup2: The length of the current Lanczos factorization')
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &           '_saup2: Extend the Lanczos factorization by')
          end if
 c
@@ -446,7 +446,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call svout (logfil, 1, rnorm, ndigit,
+            call svout (logfil, 1, [rnorm], ndigit,
      &           '_saup2: Current B-norm of residual for factorization')
          end if
 c
@@ -694,7 +694,7 @@ c
          end if
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit,
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_saup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -742,7 +742,7 @@ c
          if (ishift .eq. 0) call scopy (np, workl, 1, ritz, 1)
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_saup2: The number of shifts to apply ')
             call svout (logfil, np, workl, ndigit,
      &                  '_saup2: shifts selected')
@@ -809,7 +809,7 @@ c
   130    continue
 c
          if (msglvl .gt. 2) then
-            call svout (logfil, 1, rnorm, ndigit,
+            call svout (logfil, 1, [rnorm], ndigit,
      &      '_saup2: B-norm of residual for NEV factorization')
             call svout (logfil, nev, h(1,2), ndigit,
      &           '_saup2: main diagonal of compressed H matrix')

--- a/SRC/ssaupd.f
+++ b/SRC/ssaupd.f
@@ -628,9 +628,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_saupd: number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_saupd: number of "converged" Ritz values')
          call svout (logfil, np, workl(Ritz), ndigit,
      &               '_saupd: final Ritz values')

--- a/SRC/sseupd.f
+++ b/SRC/sseupd.f
@@ -513,9 +513,9 @@ c        | caused by incorrect passing of the _saupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, numcnv, ndigit,
+             call ivout(logfil, 1, [numcnv], ndigit,
      &            '_seupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_seupd: Number of "converged" eigenvalues')
          end if
 c

--- a/SRC/ssgets.f
+++ b/SRC/ssgets.f
@@ -202,8 +202,8 @@ c
       tsgets = tsgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_sgets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_sgets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_sgets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_sgets: NP is')
          call svout (logfil, kev+np, ritz, ndigit,
      &        '_sgets: Eigenvalues of current H matrix')
          call svout (logfil, kev+np, bounds, ndigit,

--- a/SRC/zgetv0.f
+++ b/SRC/zgetv0.f
@@ -361,9 +361,9 @@ c     | Check for further orthogonalization. |
 c     %--------------------------------------%
 c
       if (msglvl .gt. 2) then
-          call dvout (logfil, 1, rnorm0, ndigit,
+          call dvout (logfil, 1, [rnorm0], ndigit,
      &                '_getv0: re-orthonalization ; rnorm0 is')
-          call dvout (logfil, 1, rnorm, ndigit,
+          call dvout (logfil, 1, [rnorm], ndigit,
      &                '_getv0: re-orthonalization ; rnorm is')
       end if
 c
@@ -394,7 +394,7 @@ c
    50 continue
 c
       if (msglvl .gt. 0) then
-         call dvout (logfil, 1, rnorm, ndigit,
+         call dvout (logfil, 1, [rnorm], ndigit,
      &        '_getv0: B-norm of initial / restarted starting vector')
       end if
       if (msglvl .gt. 2) then

--- a/SRC/znaitr.f
+++ b/SRC/znaitr.f
@@ -378,9 +378,9 @@ c     %--------------------------------------------------------------%
  1000 continue
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call dvout (logfil, 1, rnorm, ndigit,
+            call dvout (logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
 c
@@ -400,7 +400,7 @@ c           | basis and continue the iteration.                 |
 c           %---------------------------------------------------%
 c
             if (msglvl .gt. 0) then
-               call ivout (logfil, 1, j, ndigit,
+               call ivout (logfil, 1, [j], ndigit,
      &                     '_naitr: ****** RESTART AT STEP ******')
             end if
 c
@@ -729,7 +729,7 @@ c
          end if
 c
          if (msglvl .gt. 0 .and. iter .gt. 0 ) then
-            call ivout (logfil, 1, j, ndigit,
+            call ivout (logfil, 1, [j], ndigit,
      &           '_naitr: Iterative refinement for Arnoldi residual')
             if (msglvl .gt. 2) then
                 rtemp(1) = rnorm

--- a/SRC/znapps.f
+++ b/SRC/znapps.f
@@ -268,9 +268,9 @@ c
          sigma = shift(jj)
 c
          if (msglvl .gt. 2 ) then
-            call ivout (logfil, 1, jj, ndigit,
+            call ivout (logfil, 1, [jj], ndigit,
      &               '_napps: shift number.')
-            call zvout (logfil, 1, sigma, ndigit,
+            call zvout (logfil, 1, [sigma], ndigit,
      &               '_napps: Value of the shift ')
          end if
 c
@@ -291,9 +291,9 @@ c
             if ( abs(dble(h(i+1,i)))
      &           .le. max(ulp*tst1, smlnum) )  then
                if (msglvl .gt. 0) then
-                  call ivout (logfil, 1, i, ndigit,
+                  call ivout (logfil, 1, [i], ndigit,
      &                 '_napps: matrix splitting at row/column no.')
-                  call ivout (logfil, 1, jj, ndigit,
+                  call ivout (logfil, 1, [jj], ndigit,
      &                 '_napps: matrix splitting with shift number.')
                   call zvout (logfil, 1, h(i+1,i), ndigit,
      &                 '_napps: off diagonal element.')
@@ -307,9 +307,9 @@ c
    40    continue
 c
          if (msglvl .gt. 2) then
-             call ivout (logfil, 1, istart, ndigit,
+             call ivout (logfil, 1, [istart], ndigit,
      &                   '_napps: Start of current block ')
-             call ivout (logfil, 1, iend, ndigit,
+             call ivout (logfil, 1, [iend], ndigit,
      &                   '_napps: End of current block ')
          end if
 c
@@ -485,7 +485,7 @@ c
      &        '_napps: sigmak = (e_{kev+p}^T*Q)*e_{kev}')
          call zvout (logfil, 1, h(kev+1,kev), ndigit,
      &        '_napps: betak = e_{kev+1}^T*H*e_{kev}')
-         call ivout (logfil, 1, kev, ndigit,
+         call ivout (logfil, 1, [kev], ndigit,
      &               '_napps: Order of the final Hessenberg matrix ')
          if (msglvl .gt. 2) then
             call zmout (logfil, kev, kev, h, ldh, ndigit,

--- a/SRC/znaup2.f
+++ b/SRC/znaup2.f
@@ -389,7 +389,7 @@ c
          iter = iter + 1
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, iter, ndigit,
+            call ivout (logfil, 1, [iter], ndigit,
      &           '_naup2: **** Start of major iteration number ****')
          end if
 c
@@ -402,9 +402,9 @@ c
          np  = kplusp - nev
 c
          if (msglvl .gt. 1) then
-            call ivout (logfil, 1, nev, ndigit,
+            call ivout (logfil, 1, [nev], ndigit,
      &     '_naup2: The length of the current Arnoldi factorization')
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &           '_naup2: Extend the Arnoldi factorization by')
          end if
 c
@@ -430,7 +430,7 @@ c
          update = .false.
 c
          if (msglvl .gt. 1) then
-            call dvout  (logfil, 1, rnorm, ndigit,
+            call dvout  (logfil, 1, [rnorm], ndigit,
      &           '_naup2: Corresponding B-norm of the residual')
          end if
 c
@@ -658,7 +658,7 @@ c
          end if
 c
          if (msglvl .gt. 0) then
-            call ivout (logfil, 1, nconv, ndigit,
+            call ivout (logfil, 1, [nconv], ndigit,
      &           '_naup2: no. of "converged" Ritz values at this iter.')
             if (msglvl .gt. 1) then
                kp(1) = nev
@@ -698,7 +698,7 @@ c
          end if
 c
          if (msglvl .gt. 2) then
-            call ivout (logfil, 1, np, ndigit,
+            call ivout (logfil, 1, [np], ndigit,
      &                  '_naup2: The number of shifts to apply ')
             call zvout  (logfil, np, ritz, ndigit,
      &                  '_naup2: values of the shifts')
@@ -762,7 +762,7 @@ c
          cnorm = .false.
 c
          if (msglvl .gt. 2) then
-            call dvout  (logfil, 1, rnorm, ndigit,
+            call dvout  (logfil, 1, [rnorm], ndigit,
      &      '_naup2: B-norm of residual for compressed factorization')
             call zmout  (logfil, nev, nev, h, ldh, ndigit,
      &        '_naup2: Compressed upper Hessenberg matrix H')

--- a/SRC/znaupd.f
+++ b/SRC/znaupd.f
@@ -601,9 +601,9 @@ c
       if (info .eq. 2) info = 3
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, mxiter, ndigit,
+         call ivout (logfil, 1, [mxiter], ndigit,
      &               '_naupd: Number of update iterations taken')
-         call ivout (logfil, 1, np, ndigit,
+         call ivout (logfil, 1, [np], ndigit,
      &               '_naupd: Number of wanted "converged" Ritz values')
          call zvout  (logfil, np, workl(ritz), ndigit,
      &               '_naupd: The final Ritz values')

--- a/SRC/zneupd.f
+++ b/SRC/zneupd.f
@@ -536,9 +536,9 @@ c        | caused by incorrect passing of the dnaupd data.           |
 c        %-----------------------------------------------------------%
 c
          if (msglvl .gt. 2) then
-             call ivout(logfil, 1, numcnv, ndigit,
+             call ivout(logfil, 1, [numcnv], ndigit,
      &            '_neupd: Number of specified eigenvalues')
-             call ivout(logfil, 1, nconv, ndigit,
+             call ivout(logfil, 1, [nconv], ndigit,
      &            '_neupd: Number of "converged" eigenvalues')
          end if
 c

--- a/SRC/zngets.f
+++ b/SRC/zngets.f
@@ -161,8 +161,8 @@ c
       tcgets = tcgets + (t1 - t0)
 c
       if (msglvl .gt. 0) then
-         call ivout (logfil, 1, kev, ndigit, '_ngets: KEV is')
-         call ivout (logfil, 1, np, ndigit, '_ngets: NP is')
+         call ivout (logfil, 1, [kev], ndigit, '_ngets: KEV is')
+         call ivout (logfil, 1, [np], ndigit, '_ngets: NP is')
          call zvout (logfil, kev+np, ritz, ndigit,
      &        '_ngets: Eigenvalues of current H matrix ')
          call zvout (logfil, kev+np, bounds, ndigit,


### PR DESCRIPTION
## Pull request purpose

Make arpack compatible with gcc 10

## Detailed changes proposed in this pull request

replacing scalar variables with vectors by enclosing `[]` around it, as described [in the porting guide](https://gcc.gnu.org/gcc-10/porting_to.html)

With these fixes, arpack compiles and the tests run as well with gcc 10.