### PR TITLE
Various minor improvements for fedora test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -234,15 +234,14 @@ jobs:
   - stage: fedora
     dist: xenial
     script: |
-      sudo docker pull fedora                                                               \
+      sudo docker pull registry.fedoraproject.org/fedora || sudo docker pull fedora         \
       &&                                                                                    \
       sudo docker create --name mobydick fedora /bin/bash -c                                \
-      "yum -y update                                                                     && \
-       yum -y upgrade                                                                    && \
-       yum -y groupinstall \"Development Tools\" \"Development Libraries\"               && \
-       yum -y install environment-modules                                                && \
-       yum -y install gcc gcc-c++ gcc-gfortran git cmake make                            && \
-       yum -y install openmpi openmpi-devel openblas openblas-devel                      && \
+      "dnf -y upgrade                                                                    && \
+       dnf -y groupinstall \"Development Tools\" \"Development Libraries\"               && \
+       dnf -y install environment-modules                                                   \
+                      gcc gcc-c++ gcc-gfortran git cmake make                               \
+                      openmpi openmpi-devel openblas openblas-devel                      && \
        . /etc/profile.d/modules.sh                                                       && \
        module avail                                                                      && \
        module load mpi/openmpi-x86_64                                                    && \


### PR DESCRIPTION
## Pull request purpose

(slightly) improve fedora test in travis

## Detailed changes proposed in this pull request

- `yum` is deprecated and an alias for `dnf`
- `update` is a deprecated alias to `upgrade`, so only use `upgrade`
- install all packages in one go is faster
- prefer fedoraproject registry, which is generally more up-to-date

I don't think any of the deprecated commands should be dropped any time soon, so nothing important.