### PR TITLE
Fix a typo in arpack.hpp + some issues in iso_c_binding

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 arpack-ng - 3.8.0
 
+[ Myron Oikonomakis ]
+ * [BUG FIX]: bmat return "G" instead of "B" for generalized matrix in arpack.hpp
+ * [BUG FIX]: pass arrays of chars as scalar in fortran calls in order not to crash
+ * when calling subroutines through icb interface
+
 [ Izaak "Zaak" Beekman ]
  * [BUG FIX]: fix 'Unknown CMake command "check_symbol_exists".' when ICB=ON.
 

--- a/ICB/arpack.hpp
+++ b/ICB/arpack.hpp
@@ -69,7 +69,7 @@ inline char const* convert_to_char(which const option) {
 }
 
 inline char const* convert_to_char(bmat const option) {
-  return option == bmat::identity ? "I" : "B";
+  return option == bmat::identity ? "I" : "G";
 }
 
 inline char const* convert_to_char(howmny const option) {

--- a/PARPACK/SRC/MPI/icbpcn.F90
+++ b/PARPACK/SRC/MPI/icbpcn.F90
@@ -8,7 +8,7 @@ subroutine pcnaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
 #include "arpackdef.h"
   integer(kind=c_int),          value,              intent(in)    :: comm
   integer(kind=c_int),                              intent(inout) :: ido
-  character(kind=c_char),       dimension(1),       intent(in)    :: bmat
+  character(kind=c_char),                           intent(in)    :: bmat
   integer(kind=c_int),          value,              intent(in)    :: n
   character(kind=c_char),       dimension(2),       intent(in)    :: which
   integer(kind=c_int),          value,              intent(in)    :: nev
@@ -24,7 +24,15 @@ subroutine pcnaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   integer(kind=c_int),          value,              intent(in)    :: lworkl
   complex(kind=c_float_complex),dimension(ncv),     intent(out)   :: rwork
   integer(kind=c_int),                              intent(inout) :: info
-  call pcnaupd(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+  
+  call pcnaupd(comm, ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
                iparam, ipntr, workd, workl, lworkl, rwork, info)
 end subroutine pcnaupd_c
 
@@ -37,14 +45,14 @@ subroutine pcneupd_c(comm, rvec, howmny, select, d, z, ldz, sigma, workev,&
 #include "arpackdef.h"
   integer(kind=c_int),          value,              intent(in)    :: comm
   integer(kind=c_int),          value,              intent(in)    :: rvec
-  character(kind=c_char),       dimension(1),       intent(in)    :: howmny
+  character(kind=c_char),                           intent(in)    :: howmny
   integer(kind=c_int),          dimension(ncv),     intent(in)    :: select
   complex(kind=c_float_complex),dimension(nev),     intent(out)   :: d
   complex(kind=c_float_complex),dimension(n, nev),  intent(out)   :: z
   integer(kind=c_int),          value,              intent(in)    :: ldz
   complex(kind=c_float_complex),value,              intent(in)    :: sigma
   complex(kind=c_float_complex),dimension(2*ncv),   intent(out)   :: workev
-  character(kind=c_char),       dimension(1),       intent(in)    :: bmat
+  character(kind=c_char),                           intent(in)    :: bmat
   integer(kind=c_int),          value,              intent(in)    :: n
   character(kind=c_char),       dimension(2),       intent(in)    :: which
   integer(kind=c_int),          value,              intent(in)    :: nev
@@ -66,6 +74,8 @@ subroutine pcneupd_c(comm, rvec, howmny, select, d, z, ldz, sigma, workev,&
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
+  character(len=2):: w
+  integer         :: i
 
   rv = .false.
   if (rvec .ne. 0) rv = .true.
@@ -74,10 +84,14 @@ subroutine pcneupd_c(comm, rvec, howmny, select, d, z, ldz, sigma, workev,&
   do idx=1, ncv
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
 
   ! call arpack.
 
   call pcneupd(comm, rv, howmny, slt, d, z, ldz, sigma, workev,&
-               bmat, n, which, nev, tol, resid, ncv, v, ldv,   &
+               bmat, n, w, nev, tol, resid, ncv, v, ldv,   &
                iparam, ipntr, workd, workl, lworkl, rwork, info)
 end subroutine pcneupd_c

--- a/PARPACK/SRC/MPI/icbpdn.F90
+++ b/PARPACK/SRC/MPI/icbpdn.F90
@@ -8,7 +8,7 @@ subroutine pdnaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: comm
   integer(kind=c_int),                         intent(inout) :: ido
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -23,7 +23,15 @@ subroutine pdnaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   real(kind=c_double),    dimension(lworkl),   intent(out)   :: workl
   integer(kind=c_int),    value,               intent(in)    :: lworkl
   integer(kind=c_int),                         intent(inout) :: info
-  call pdnaupd(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+  
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+  
+  call pdnaupd(comm, ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
                iparam, ipntr, workd, workl, lworkl, info)
 end subroutine pdnaupd_c
 
@@ -37,7 +45,7 @@ subroutine pdneupd_c(comm, rvec, howmny, select,                  &
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: comm
   integer(kind=c_int),    value,               intent(in)    :: rvec
-  character(kind=c_char), dimension(1),        intent(in)    :: howmny
+  character(kind=c_char),                      intent(in)    :: howmny
   integer(kind=c_int),    dimension(ncv),      intent(in)    :: select
   real(kind=c_double),    dimension(nev+1),    intent(out)   :: dr
   real(kind=c_double),    dimension(nev+1),    intent(out)   :: di
@@ -46,7 +54,7 @@ subroutine pdneupd_c(comm, rvec, howmny, select,                  &
   real(kind=c_double),    value,               intent(in)    :: sigmar
   real(kind=c_double),    value,               intent(in)    :: sigmai
   real(kind=c_double),    dimension(3*ncv),    intent(out)   :: workev
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -67,7 +75,9 @@ subroutine pdneupd_c(comm, rvec, howmny, select,                  &
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
-
+  character(len=2):: w
+  integer         :: i
+  
   rv = .false.
   if (rvec .ne. 0) rv = .true.
 
@@ -76,10 +86,14 @@ subroutine pdneupd_c(comm, rvec, howmny, select,                  &
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
 
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+
   ! call arpack.
 
   call pdneupd(comm, rv, howmny, slt,                       &
                dr, di, z, ldz, sigmar, sigmai, workev,      &
-               bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+               bmat, n, w, nev, tol, resid, ncv, v, ldv,&
                iparam, ipntr, workd, workl, lworkl, info)
 end subroutine pdneupd_c

--- a/PARPACK/SRC/MPI/icbpds.F90
+++ b/PARPACK/SRC/MPI/icbpds.F90
@@ -8,7 +8,7 @@ subroutine pdsaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: comm
   integer(kind=c_int),                         intent(inout) :: ido
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -23,7 +23,15 @@ subroutine pdsaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   real(kind=c_double),    dimension(lworkl),   intent(out)   :: workl
   integer(kind=c_int),    value,               intent(in)    :: lworkl
   integer(kind=c_int),                         intent(inout) :: info
-  call pdsaupd(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+
+  call pdsaupd(comm, ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
                iparam, ipntr, workd, workl, lworkl, info)
 end subroutine pdsaupd_c
 
@@ -36,13 +44,13 @@ subroutine pdseupd_c(comm, rvec, howmny, select, d, z, ldz, sigma,&
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: comm
   integer(kind=c_int),    value,               intent(in)    :: rvec
-  character(kind=c_char), dimension(1),        intent(in)    :: howmny
+  character(kind=c_char),                      intent(in)    :: howmny
   integer(kind=c_int),    dimension(ncv),      intent(in)    :: select
   real(kind=c_double),    dimension(nev),      intent(out)   :: d
   real(kind=c_double),    dimension(n, nev),   intent(out)   :: z
   integer(kind=c_int),    value,               intent(in)    :: ldz
   real(kind=c_double),    value,               intent(in)    :: sigma
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -63,6 +71,8 @@ subroutine pdseupd_c(comm, rvec, howmny, select, d, z, ldz, sigma,&
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
+  character(len=2):: w
+  integer         :: i
 
   rv = .false.
   if (rvec .ne. 0) rv = .true.
@@ -71,10 +81,14 @@ subroutine pdseupd_c(comm, rvec, howmny, select, d, z, ldz, sigma,&
   do idx=1, ncv
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
 
   ! call arpack.
 
   call pdseupd(comm, rv, howmny, slt, d, z, ldz, sigma,     &
-               bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+               bmat, n, w, nev, tol, resid, ncv, v, ldv,&
                iparam, ipntr, workd, workl, lworkl, info)
 end subroutine pdseupd_c

--- a/PARPACK/SRC/MPI/icbpsn.F90
+++ b/PARPACK/SRC/MPI/icbpsn.F90
@@ -8,7 +8,7 @@ subroutine psnaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: comm
   integer(kind=c_int),                         intent(inout) :: ido
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -23,7 +23,15 @@ subroutine psnaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   real(kind=c_float),     dimension(lworkl),   intent(out)   :: workl
   integer(kind=c_int),    value,               intent(in)    :: lworkl
   integer(kind=c_int),                         intent(inout) :: info
-  call psnaupd(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+  
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+  
+  call psnaupd(comm, ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
                iparam, ipntr, workd, workl, lworkl, info)
 end subroutine psnaupd_c
 
@@ -37,7 +45,7 @@ subroutine psneupd_c(comm, rvec, howmny, select,                  &
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: comm
   integer(kind=c_int),    value,               intent(in)    :: rvec
-  character(kind=c_char), dimension(1),        intent(in)    :: howmny
+  character(kind=c_char),                      intent(in)    :: howmny
   integer(kind=c_int),    dimension(ncv),      intent(in)    :: select
   real(kind=c_float),     dimension(nev+1),    intent(out)   :: dr
   real(kind=c_float),     dimension(nev+1),    intent(out)   :: di
@@ -46,7 +54,7 @@ subroutine psneupd_c(comm, rvec, howmny, select,                  &
   real(kind=c_float),     value,               intent(in)    :: sigmar
   real(kind=c_float),     value,               intent(in)    :: sigmai
   real(kind=c_float),     dimension(3*ncv),    intent(out)   :: workev
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -67,6 +75,8 @@ subroutine psneupd_c(comm, rvec, howmny, select,                  &
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
+  character(len=2):: w
+  integer         :: i
 
   rv = .false.
   if (rvec .ne. 0) rv = .true.
@@ -76,10 +86,14 @@ subroutine psneupd_c(comm, rvec, howmny, select,                  &
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
 
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+
   ! call arpack.
 
   call psneupd(comm, rv, howmny, slt,                       &
                dr, di, z, ldz, sigmar, sigmai, workev,      &
-               bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+               bmat, n, w, nev, tol, resid, ncv, v, ldv,&
                iparam, ipntr, workd, workl, lworkl, info)
 end subroutine psneupd_c

--- a/PARPACK/SRC/MPI/icbpss.F90
+++ b/PARPACK/SRC/MPI/icbpss.F90
@@ -8,7 +8,7 @@ subroutine pssaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: comm
   integer(kind=c_int),                         intent(inout) :: ido
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -23,7 +23,15 @@ subroutine pssaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   real(kind=c_float),     dimension(lworkl),   intent(out)   :: workl
   integer(kind=c_int),    value,               intent(in)    :: lworkl
   integer(kind=c_int),                         intent(inout) :: info
-  call pssaupd(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+  
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+  
+  call pssaupd(comm, ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
                iparam, ipntr, workd, workl, lworkl, info)
 end subroutine pssaupd_c
 
@@ -36,13 +44,13 @@ subroutine psseupd_c(comm, rvec, howmny, select, d, z, ldz, sigma,&
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: comm
   integer(kind=c_int),    value,               intent(in)    :: rvec
-  character(kind=c_char), dimension(1),        intent(in)    :: howmny
+  character(kind=c_char),                      intent(in)    :: howmny
   integer(kind=c_int),    dimension(ncv),      intent(in)    :: select
   real(kind=c_float),     dimension(nev),      intent(out)   :: d
   real(kind=c_float),     dimension(n, nev),   intent(out)   :: z
   integer(kind=c_int),    value,               intent(in)    :: ldz
   real(kind=c_float),     value,               intent(in)    :: sigma
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -63,7 +71,9 @@ subroutine psseupd_c(comm, rvec, howmny, select, d, z, ldz, sigma,&
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
-
+  character(len=2):: w
+  integer         :: i
+  
   rv = .false.
   if (rvec .ne. 0) rv = .true.
 
@@ -71,10 +81,14 @@ subroutine psseupd_c(comm, rvec, howmny, select, d, z, ldz, sigma,&
   do idx=1, ncv
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
 
   ! call arpack.
 
   call psseupd(comm, rv, howmny, slt, d, z, ldz, sigma,     &
-               bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+               bmat, n, w, nev, tol, resid, ncv, v, ldv,&
                iparam, ipntr, workd, workl, lworkl, info)
 end subroutine psseupd_c

--- a/PARPACK/SRC/MPI/icbpzn.F90
+++ b/PARPACK/SRC/MPI/icbpzn.F90
@@ -8,7 +8,7 @@ subroutine pznaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
 #include "arpackdef.h"
   integer(kind=c_int),              value,              intent(in)    :: comm
   integer(kind=c_int),                                  intent(inout) :: ido
-  character(kind=c_char),           dimension(1),       intent(in)    :: bmat
+  character(kind=c_char),                               intent(in)    :: bmat
   integer(kind=c_int),              value,              intent(in)    :: n
   character(kind=c_char),           dimension(2),       intent(in)    :: which
   integer(kind=c_int),              value,              intent(in)    :: nev
@@ -24,7 +24,15 @@ subroutine pznaupd_c(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   integer(kind=c_int),              value,              intent(in)    :: lworkl
   complex(kind=c_double_complex),   dimension(ncv),     intent(out)   :: rwork
   integer(kind=c_int),                                  intent(inout) :: info
-  call pznaupd(comm, ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+  
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+  
+  call pznaupd(comm, ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
                iparam, ipntr, workd, workl, lworkl, rwork, info)
 end subroutine pznaupd_c
 
@@ -37,14 +45,14 @@ subroutine pzneupd_c(comm, rvec, howmny, select, d, z, ldz, sigma, workev,&
 #include "arpackdef.h"
   integer(kind=c_int),              value,              intent(in)    :: comm
   integer(kind=c_int),              value,              intent(in)    :: rvec
-  character(kind=c_char),           dimension(1),       intent(in)    :: howmny
+  character(kind=c_char),                               intent(in)    :: howmny
   integer(kind=c_int),              dimension(ncv),     intent(in)    :: select
   complex(kind=c_double_complex),   dimension(nev),     intent(out)   :: d
   complex(kind=c_double_complex),   dimension(n, nev),  intent(out)   :: z
   integer(kind=c_int),              value,              intent(in)    :: ldz
   complex(kind=c_double_complex),   value,              intent(in)    :: sigma
   complex(kind=c_double_complex),   dimension(2*ncv),   intent(out)   :: workev
-  character(kind=c_char),           dimension(1),       intent(in)    :: bmat
+  character(kind=c_char),                               intent(in)    :: bmat
   integer(kind=c_int),              value,              intent(in)    :: n
   character(kind=c_char),           dimension(2),       intent(in)    :: which
   integer(kind=c_int),              value,              intent(in)    :: nev
@@ -66,7 +74,9 @@ subroutine pzneupd_c(comm, rvec, howmny, select, d, z, ldz, sigma, workev,&
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
-
+  character(len=2):: w
+  integer         :: i
+  
   rv = .false.
   if (rvec .ne. 0) rv = .true.
 
@@ -74,10 +84,14 @@ subroutine pzneupd_c(comm, rvec, howmny, select, d, z, ldz, sigma, workev,&
   do idx=1, ncv
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
 
   ! call arpack.
 
   call pzneupd(comm, rv, howmny, slt, d, z, ldz, sigma, workev,&
-               bmat, n, which, nev, tol, resid, ncv, v, ldv,   &
+               bmat, n, w, nev, tol, resid, ncv, v, ldv,   &
                iparam, ipntr, workd, workl, lworkl, rwork, info)
 end subroutine pzneupd_c

--- a/SRC/icbacn.F90
+++ b/SRC/icbacn.F90
@@ -7,7 +7,7 @@ subroutine cnaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),                              intent(inout) :: ido
-  character(kind=c_char),       dimension(1),       intent(in)    :: bmat
+  character(kind=c_char),                           intent(in)    :: bmat
   integer(kind=c_int),          value,              intent(in)    :: n
   character(kind=c_char),       dimension(2),       intent(in)    :: which
   integer(kind=c_int),          value,              intent(in)    :: nev
@@ -23,7 +23,15 @@ subroutine cnaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   integer(kind=c_int),          value,              intent(in)    :: lworkl
   real(kind=c_float),           dimension(ncv),     intent(out)   :: rwork
   integer(kind=c_int),                              intent(inout) :: info
-  call cnaupd(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+  
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+
+  call cnaupd(ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
               iparam, ipntr, workd, workl, lworkl, rwork, info)
 end subroutine cnaupd_c
 
@@ -35,14 +43,14 @@ subroutine cneupd_c(rvec, howmny, select, d, z, ldz, sigma, workev,  &
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),          value,              intent(in)    :: rvec
-  character(kind=c_char),       dimension(1),       intent(in)    :: howmny
+  character(kind=c_char),                           intent(in)    :: howmny
   integer(kind=c_int),          dimension(ncv),     intent(in)    :: select
   complex(kind=c_float_complex),dimension(nev),     intent(out)   :: d
   complex(kind=c_float_complex),dimension(n, nev),  intent(out)   :: z
   integer(kind=c_int),          value,              intent(in)    :: ldz
   complex(kind=c_float_complex),value,              intent(in)    :: sigma
   complex(kind=c_float_complex),dimension(2*ncv),   intent(out)   :: workev
-  character(kind=c_char),       dimension(1),       intent(in)    :: bmat
+  character(kind=c_char),                           intent(in)    :: bmat
   integer(kind=c_int),          value,              intent(in)    :: n
   character(kind=c_char),       dimension(2),       intent(in)    :: which
   integer(kind=c_int),          value,              intent(in)    :: nev
@@ -64,7 +72,9 @@ subroutine cneupd_c(rvec, howmny, select, d, z, ldz, sigma, workev,  &
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
-
+  character(len=2):: w
+  integer         :: i
+  
   rv = .false.
   if (rvec .ne. 0) rv = .true.
 
@@ -73,9 +83,12 @@ subroutine cneupd_c(rvec, howmny, select, d, z, ldz, sigma, workev,  &
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
 
+  do i =1,2
+      w(i:i) = which(i)
+  end do
   ! call arpack.
 
   call cneupd(rv, howmny, slt, d, z, ldz, sigma, workev,     &
-              bmat, n, which, nev, tol, resid, ncv, v, ldv,  &
+              bmat, n, w, nev, tol, resid, ncv, v, ldv,  &
               iparam, ipntr, workd, workl, lworkl, rwork, info)
 end subroutine cneupd_c

--- a/SRC/icbadn.F90
+++ b/SRC/icbadn.F90
@@ -7,7 +7,7 @@ subroutine dnaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),                         intent(inout) :: ido
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -22,7 +22,15 @@ subroutine dnaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   real(kind=c_double),    dimension(lworkl),   intent(out)   :: workl
   integer(kind=c_int),    value,               intent(in)    :: lworkl
   integer(kind=c_int),                         intent(inout) :: info
-  call dnaupd(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+  
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+
+  call dnaupd(ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
               iparam, ipntr, workd, workl, lworkl, info)
 end subroutine dnaupd_c
 
@@ -35,7 +43,7 @@ subroutine dneupd_c(rvec, howmny, select,                        &
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: rvec
-  character(kind=c_char), dimension(1),        intent(in)    :: howmny
+  character(kind=c_char),                      intent(in)    :: howmny
   integer(kind=c_int),    dimension(ncv),      intent(in)    :: select
   real(kind=c_double),    dimension(nev+1),    intent(out)   :: dr
   real(kind=c_double),    dimension(nev+1),    intent(out)   :: di
@@ -44,7 +52,7 @@ subroutine dneupd_c(rvec, howmny, select,                        &
   real(kind=c_double),    value,               intent(in)    :: sigmar
   real(kind=c_double),    value,               intent(in)    :: sigmai
   real(kind=c_double),    dimension(3*ncv),    intent(out)   :: workev
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -65,6 +73,8 @@ subroutine dneupd_c(rvec, howmny, select,                        &
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
+  character(len=2):: w
+  integer         :: i
 
   rv = .false.
   if (rvec .ne. 0) rv = .true.
@@ -73,11 +83,15 @@ subroutine dneupd_c(rvec, howmny, select,                        &
   do idx=1, ncv
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
 
   ! call arpack.
 
   call dneupd(rv, howmny, slt,                             &
               dr, di, z, ldz, sigmar, sigmai, workev,      &
-              bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+              bmat, n, w, nev, tol, resid, ncv, v, ldv,&
               iparam, ipntr, workd, workl, lworkl, info)
 end subroutine dneupd_c

--- a/SRC/icbads.F90
+++ b/SRC/icbads.F90
@@ -7,7 +7,7 @@ subroutine dsaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),                         intent(inout) :: ido
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -22,7 +22,15 @@ subroutine dsaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   real(kind=c_double),    dimension(lworkl),   intent(out)   :: workl
   integer(kind=c_int),    value,               intent(in)    :: lworkl
   integer(kind=c_int),                         intent(inout) :: info
-  call dsaupd(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+  
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+
+  call dsaupd(ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
               iparam, ipntr, workd, workl, lworkl, info)
 end subroutine dsaupd_c
 
@@ -34,13 +42,13 @@ subroutine dseupd_c(rvec, howmny, select, d, z, ldz, sigma,      &
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: rvec
-  character(kind=c_char), dimension(1),        intent(in)    :: howmny
+  character(kind=c_char),                      intent(in)    :: howmny
   integer(kind=c_int),    dimension(ncv),      intent(in)    :: select
   real(kind=c_double),    dimension(nev),      intent(out)   :: d
   real(kind=c_double),    dimension(n, nev),   intent(out)   :: z
   integer(kind=c_int),    value,               intent(in)    :: ldz
   real(kind=c_double),    value,               intent(in)    :: sigma
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -61,6 +69,8 @@ subroutine dseupd_c(rvec, howmny, select, d, z, ldz, sigma,      &
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
+  character(len=2):: w
+  integer         :: i
 
   rv = .false.
   if (rvec .ne. 0) rv = .true.
@@ -70,9 +80,13 @@ subroutine dseupd_c(rvec, howmny, select, d, z, ldz, sigma,      &
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
 
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+
   ! call arpack.
 
   call dseupd(rv, howmny, slt, d, z, ldz, sigma,           &
-              bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+              bmat, n, w, nev, tol, resid, ncv, v, ldv,&
               iparam, ipntr, workd, workl, lworkl, info)
 end subroutine dseupd_c

--- a/SRC/icbasn.F90
+++ b/SRC/icbasn.F90
@@ -7,7 +7,7 @@ subroutine snaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),                         intent(inout) :: ido
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -22,7 +22,15 @@ subroutine snaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   real(kind=c_float),     dimension(lworkl),   intent(out)   :: workl
   integer(kind=c_int),    value,               intent(in)    :: lworkl
   integer(kind=c_int),                         intent(inout) :: info
-  call snaupd(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+  
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+
+  call snaupd(ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
               iparam, ipntr, workd, workl, lworkl, info)
 end subroutine snaupd_c
 
@@ -35,7 +43,7 @@ subroutine sneupd_c(rvec, howmny, select,                        &
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: rvec
-  character(kind=c_char), dimension(1),        intent(in)    :: howmny
+  character(kind=c_char),                     intent(in)    :: howmny
   integer(kind=c_int),    dimension(ncv),      intent(in)    :: select
   real(kind=c_float),     dimension(nev+1),    intent(out)   :: dr
   real(kind=c_float),     dimension(nev+1),    intent(out)   :: di
@@ -44,7 +52,7 @@ subroutine sneupd_c(rvec, howmny, select,                        &
   real(kind=c_float),     value,               intent(in)    :: sigmar
   real(kind=c_float),     value,               intent(in)    :: sigmai
   real(kind=c_float),     dimension(3*ncv),    intent(out)   :: workev
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -65,7 +73,9 @@ subroutine sneupd_c(rvec, howmny, select,                        &
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
-
+  character(len=2):: w
+  integer         :: i
+  
   rv = .false.
   if (rvec .ne. 0) rv = .true.
 
@@ -74,10 +84,13 @@ subroutine sneupd_c(rvec, howmny, select,                        &
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
 
+  do i =1,2
+      w(i:i) = which(i)
+  end do
   ! call arpack.
 
   call sneupd(rv, howmny, slt,                             &
               dr, di, z, ldz, sigmar, sigmai, workev,      &
-              bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+              bmat, n, w, nev, tol, resid, ncv, v, ldv,&
               iparam, ipntr, workd, workl, lworkl, info)
 end subroutine sneupd_c

--- a/SRC/icbass.F90
+++ b/SRC/icbass.F90
@@ -7,7 +7,7 @@ subroutine ssaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),                         intent(inout) :: ido
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -22,7 +22,15 @@ subroutine ssaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   real(kind=c_float),     dimension(lworkl),   intent(out)   :: workl
   integer(kind=c_int),    value,               intent(in)    :: lworkl
   integer(kind=c_int),                         intent(inout) :: info
-  call ssaupd(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+  
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+  
+  call ssaupd(ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
               iparam, ipntr, workd, workl, lworkl, info)
 end subroutine ssaupd_c
 
@@ -34,13 +42,13 @@ subroutine sseupd_c(rvec, howmny, select, d, z, ldz, sigma,      &
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),    value,               intent(in)    :: rvec
-  character(kind=c_char), dimension(1),        intent(in)    :: howmny
+  character(kind=c_char),                      intent(in)    :: howmny
   integer(kind=c_int),    dimension(ncv),      intent(in)    :: select
   real(kind=c_float),     dimension(nev),      intent(out)   :: d
   real(kind=c_float),     dimension(n, nev),   intent(out)   :: z
   integer(kind=c_int),    value,               intent(in)    :: ldz
   real(kind=c_float),     value,               intent(in)    :: sigma
-  character(kind=c_char), dimension(1),        intent(in)    :: bmat
+  character(kind=c_char),                      intent(in)    :: bmat
   integer(kind=c_int),    value,               intent(in)    :: n
   character(kind=c_char), dimension(2),        intent(in)    :: which
   integer(kind=c_int),    value,               intent(in)    :: nev
@@ -61,6 +69,8 @@ subroutine sseupd_c(rvec, howmny, select, d, z, ldz, sigma,      &
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
+  character(len=2):: w
+  integer         :: i
 
   rv = .false.
   if (rvec .ne. 0) rv = .true.
@@ -69,10 +79,14 @@ subroutine sseupd_c(rvec, howmny, select, d, z, ldz, sigma,      &
   do idx=1, ncv
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
 
   ! call arpack.
 
   call sseupd(rv, howmny, slt, d, z, ldz, sigma,           &
-              bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+              bmat, n, w, nev, tol, resid, ncv, v, ldv,&
               iparam, ipntr, workd, workl, lworkl, info)
 end subroutine sseupd_c

--- a/SRC/icbazn.F90
+++ b/SRC/icbazn.F90
@@ -7,7 +7,7 @@ subroutine znaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),                                  intent(inout) :: ido
-  character(kind=c_char),           dimension(1),       intent(in)    :: bmat
+  character(kind=c_char),                               intent(in)    :: bmat
   integer(kind=c_int),              value,              intent(in)    :: n
   character(kind=c_char),           dimension(2),       intent(in)    :: which
   integer(kind=c_int),              value,              intent(in)    :: nev
@@ -23,7 +23,15 @@ subroutine znaupd_c(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
   integer(kind=c_int),              value,              intent(in)    :: lworkl
   real(kind=c_double),              dimension(ncv),     intent(out)   :: rwork
   integer(kind=c_int),                                  intent(inout) :: info
-  call znaupd(ido, bmat, n, which, nev, tol, resid, ncv, v, ldv,&
+  
+  character(len=2):: w
+  integer         :: i
+  
+  do i =1,2
+      w(i:i) = which(i)
+  end do
+  
+  call znaupd(ido, bmat, n, w, nev, tol, resid, ncv, v, ldv,&
               iparam, ipntr, workd, workl, lworkl, rwork, info)
 end subroutine znaupd_c
 
@@ -35,14 +43,14 @@ subroutine zneupd_c(rvec, howmny, select, d, z, ldz, sigma, workev,  &
   implicit none
 #include "arpackdef.h"
   integer(kind=c_int),              value,              intent(in)    :: rvec
-  character(kind=c_char),           dimension(1),       intent(in)    :: howmny
+  character(kind=c_char),                               intent(in)    :: howmny
   integer(kind=c_int),              dimension(ncv),     intent(in)    :: select
   complex(kind=c_double_complex),   dimension(nev),     intent(out)   :: d
   complex(kind=c_double_complex),   dimension(n, nev),  intent(out)   :: z
   integer(kind=c_int),              value,              intent(in)    :: ldz
   complex(kind=c_double_complex),   value,              intent(in)    :: sigma
   complex(kind=c_double_complex),   dimension(2*ncv),   intent(out)   :: workev
-  character(kind=c_char),           dimension(1),       intent(in)    :: bmat
+  character(kind=c_char),                               intent(in)    :: bmat
   integer(kind=c_int),              value,              intent(in)    :: n
   character(kind=c_char),           dimension(2),       intent(in)    :: which
   integer(kind=c_int),              value,              intent(in)    :: nev
@@ -64,6 +72,8 @@ subroutine zneupd_c(rvec, howmny, select, d, z, ldz, sigma, workev,  &
   logical :: rv
   logical, dimension(ncv) :: slt
   integer :: idx
+  character(len=2):: w
+  integer         :: i
 
   rv = .false.
   if (rvec .ne. 0) rv = .true.
@@ -73,9 +83,12 @@ subroutine zneupd_c(rvec, howmny, select, d, z, ldz, sigma, workev,  &
     if (select(idx) .ne. 0) slt(idx) = .true.
   enddo
 
+  do i =1,2
+      w(i:i) = which(i)
+  end do
   ! call arpack.
 
   call zneupd(rv, howmny, slt, d, z, ldz, sigma, workev,     &
-              bmat, n, which, nev, tol, resid, ncv, v, ldv,  &
+              bmat, n, w, nev, tol, resid, ncv, v, ldv,  &
               iparam, ipntr, workd, workl, lworkl, rwork, info)
 end subroutine zneupd_c


### PR DESCRIPTION
## Pull request purpose

Fix errors in order to use Arpack routines from C++ calls

## Detailed changes proposed in this pull request

- Fix typo in arpack.hpp. bmat for general matrix was "B" instead of "G"
- Fix in iso_c_binding (.F90 files) pass scalar arguments instead of array of chars which caused instant crashes

The above were tested in Windows using Microsoft Visual Studio 2017 & 2019 and Intel Fortran 2020 compiler.
