### PR TITLE
[CLEAN - TravisCI]: use bionic as it's now provided by TravisCI !

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -226,7 +226,7 @@ jobs:
       head -n 50 coveralls.log && tail -n 50 coveralls.log                         \
       &&                                                                           \
       head -n 50 coveralls.json && tail -n 50 coveralls.json
-  # xenial <=> interface64: "recent" systems with ICB + MKL + ILP64 (need debian/testing to get MKL-ILP64)
+  # xenial <=> interface64: "recent" systems with ICB + MKL + ILP64
   #   note: when you PR, docker-cp provides, in the container, the branch associated with the PR (not master where there's nothing new)
   #         1. docker create --name mobydick IMAGE CMD        <=> create a container (= instance of image) but container is NOT yet started
   #         2. docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp <=> copy git repository (CI worker, checkout-ed on PR branch) into the container
@@ -236,15 +236,10 @@ jobs:
     allow_failure:
     dist: xenial
     script: |
-      sudo docker pull debian                                                                                           \
+      sudo docker pull ubuntu:bionic                                                                                    \
       &&                                                                                                                \
-      sudo docker create --name mobydick debian /bin/bash -c                                                            \
+      sudo docker create --name mobydick ubuntu:bionic /bin/bash -c                                                     \
       "cat /etc/os-release                                                                                           && \
-       cat /etc/apt/sources.list                                                                                     && \
-       sed -e 's/stretch/testing/'            -i /etc/apt/sources.list                                               && \
-       sed -e 's/main/main non-free contrib/' -i /etc/apt/sources.list                                               && \
-       sed -e '/security.debian.org/d'        -i /etc/apt/sources.list                                               && \
-       cat /etc/apt/sources.list                                                                                     && \
        export DEBIAN_FRONTEND=noninteractive                                                                         && \
        apt-get -y                                                                 update                             && \
        apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef      upgrade                            && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -250,7 +250,7 @@ jobs:
        apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef      upgrade                            && \
        apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef dist-upgrade                            && \
        cat /etc/os-release                                                                                           && \
-       apt-get -y install dialog apt-utils                                                                           && \
+       apt-get -y install dialog                                                                                     && \
        echo yes | apt-get -y install intel-mkl libmkl-dev                                                            && \
        apt-get -y install build-essential                                                                            && \
        apt-get -y install git gfortran gcc g++ openmpi-bin libopenmpi-dev automake autoconf libtool pkg-config       && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,10 @@ jobs:
     - sudo ./b2 install
     - sudo apt-get install locate
     - sudo updatedb
-    script: mkdir -p build && cd build && cmake -DEXAMPLES=ON -DICB=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' .. && export VERBOSE=1 && make all && make test
+    script: |
+      cd $TRAVIS_BUILD_DIR && mkdir -p build && cd build &&                                  \
+      cmake -DEXAMPLES=ON -DICB=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' .. && \
+      export VERBOSE=1 && make all && make test
   # bionic <=> coverage: "recent" systems with ICB
   - stage: coverage
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,82 +130,35 @@ jobs:
   - stage: xenial
     dist: xenial
     script: ./bootstrap && ./configure --enable-mpi --enable-icb                        && make VERBOSE=1 && make check && make distcheck;
-  # bionic <=> test ubuntu:bionic with autotools/cmake
-  #   note: when you PR, docker-cp provides, in the container, the branch associated with the PR (not master where there's nothing new)
-  #         1. docker create --name mobydick IMAGE CMD        <=> create a container (= instance of image) but container is NOT yet started
-  #         2. docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp <=> copy git repository (CI worker, checkout-ed on PR branch) into the container
-  #                                                               note: docker-cp works only if copy from/to containers (not images)
-  #         3. docker start -a mobydick                       <=> start to run the container (initialized with docker-cp)
+  # bionic <=> test "recent" systems, with ICB
   - stage: bionic
-    dist: xenial
+    dist: bionic
     script: |
-      sudo docker pull ubuntu:bionic                                                                                    \
-      &&                                                                                                                \
-      sudo docker create --name mobydick ubuntu:bionic /bin/bash -c                                                     \
-      "cat /etc/os-release                                                                                           && \
-       apt-get -y                                                                 update                             && \
-       apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef      upgrade                            && \
-       apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef dist-upgrade                            && \
-       apt-get -y install build-essential                                                                            && \
-       apt-get -y install git gfortran gcc g++ openmpi-bin libopenmpi-dev automake autoconf libtool pkg-config       && \
-       apt-get -y install libblas-dev liblapack-dev                                                                  && \
-       cd /tmp                                                                                                       && \
-       cd arpack-ng                                                                                                  && \
-       git status                                                                                                    && \
-       git log -2                                                                                                    && \
-       sed -e 's/LOG_FLAGS = /LOG_FLAGS = --allow-run-as-root --oversubscribe /' -i PARPACK/EXAMPLES/MPI/Makefile.am && \
-       sed -e 's/LOG_FLAGS = /LOG_FLAGS = --allow-run-as-root --oversubscribe /' -i PARPACK/TESTS/MPI/Makefile.am    && \
-       ./bootstrap                                                                                                   && \
-       ./configure --enable-icb --enable-mpi --disable-dependency-tracking                                           && \
-       export VERBOSE=1                                                                                              && \
-       make all                                                                                                      && \
-       make check                                                                                                    && \
-       find . -name test-suite.log | xargs tail -n 300"                                                                 \
-      &&                                                                                                                \
-      sudo docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp                                                               \
-      &&                                                                                                                \
-      sudo docker start -a mobydick
+      ./bootstrap                           && \
+      ./configure --enable-icb --enable-mpi && \
+      export VERBOSE=1                      && \
+      make all                              && \
+      make check                            && \
   - stage: bionic
-    dist: xenial
+    dist: bionic
     script: |
-      sudo docker pull ubuntu:bionic                                                         \
-      &&                                                                                     \
-      sudo docker create --name mobydick ubuntu:bionic /bin/bash -c                          \
-      "cat /etc/os-release                                                                && \
-       apt-get -y                                                                 update  && \
-       apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef      upgrade && \
-       apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef dist-upgrade && \
-       apt-get -y install build-essential                                                 && \
-       apt-get -y install git gfortran gcc g++ openmpi-bin libopenmpi-dev cmake           && \
-       apt-get -y install libblas-dev liblapack-dev                                       && \
-       apt-get -y install libeigen3-dev                                                   && \
-       apt-get -y install python3-minimal python3-pip python3-numpy                       && \
-       pip3 install numpy                                                                 && \
-       apt-get -y install wget                                                            && \
-       wget https://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.tar.gz && \
-       tar -xf boost_1_67_0.tar.gz && cd boost_1_67_0                                     && \
-       ./bootstrap.sh --with-libraries=python --with-python=/usr/bin/python3              && \
-       ./b2 install                                                                       && \
-       apt-get install locate                                                             && \
-       updatedb                                                                           && \
-       cd /tmp                                                                            && \
-       cd arpack-ng                                                                       && \
-       git status                                                                         && \
-       git log -2                                                                         && \
-       sed -e 's/mpirun /mpirun --allow-run-as-root --oversubscribe /' -i CMakeLists.txt  && \
-       mkdir -p build && cd build                                                         && \
-       cmake -DEXAMPLES=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' ..         && \
-       export VERBOSE=1                                                                   && \
-       make all                                                                           && \
-       make test                                                                          && \
-       tail -n 300 ./Testing/Temporary/LastTest.log"                                         \
-      &&                                                                                     \
-      sudo docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp                                    \
-      &&                                                                                     \
-      sudo docker start -a mobydick
-  # xenial <=> coverage: "recent" systems with ICB
+      apt-get -y install python3-minimal python3-pip python3-numpy                       && \
+      pip3 install numpy                                                                 && \
+      apt-get -y install wget                                                            && \
+      wget https://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.tar.gz && \
+      tar -xf boost_1_67_0.tar.gz && cd boost_1_67_0                                     && \
+      ./bootstrap.sh --with-libraries=python --with-python=/usr/bin/python3              && \
+      ./b2 install                                                                       && \
+      apt-get install locate                                                             && \
+      updatedb                                                                           && \
+      mkdir -p build && cd build                                                         && \
+      cmake -DEXAMPLES=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' ..         && \
+      export VERBOSE=1                                                                   && \
+      make all                                                                           && \
+      make test                                                                          && \
+  # bionic <=> coverage: "recent" systems with ICB
   - stage: coverage
-    dist: xenial
+    dist: bionic
     script: |
       mkdir -p build && cd build                                                   \
       &&                                                                           \
@@ -226,59 +179,29 @@ jobs:
       head -n 50 coveralls.log && tail -n 50 coveralls.log                         \
       &&                                                                           \
       head -n 50 coveralls.json && tail -n 50 coveralls.json
-  # xenial <=> interface64: "recent" systems with ICB + MKL + ILP64
-  #   note: when you PR, docker-cp provides, in the container, the branch associated with the PR (not master where there's nothing new)
-  #         1. docker create --name mobydick IMAGE CMD        <=> create a container (= instance of image) but container is NOT yet started
-  #         2. docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp <=> copy git repository (CI worker, checkout-ed on PR branch) into the container
-  #                                                               note: docker-cp works only if copy from/to containers (not images)
-  #         3. docker start -a mobydick                       <=> start to run the container (initialized with docker-cp)
+  # bionic <=> interface64: "recent" systems with ICB + MKL + ILP64
   - stage: interface64
-    allow_failure:
-    dist: xenial
+    dist: bionic
     script: |
-      sudo docker pull ubuntu:bionic                                                                                    \
-      &&                                                                                                                \
-      sudo docker create --name mobydick ubuntu:bionic /bin/bash -c                                                     \
-      "cat /etc/os-release                                                                                           && \
-       export DEBIAN_FRONTEND=noninteractive                                                                         && \
-       apt-get -y                                                                 update                             && \
-       apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef      upgrade                            && \
-       apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef dist-upgrade                            && \
-       cat /etc/os-release                                                                                           && \
-       apt-get -y install dialog                                                                                     && \
-       echo yes | apt-get -y install intel-mkl libmkl-dev                                                            && \
-       apt-get -y install build-essential                                                                            && \
-       apt-get -y install git gfortran gcc g++ openmpi-bin libopenmpi-dev automake autoconf libtool pkg-config       && \
-       apt-get -y install libeigen3-dev                                                                              && \
-       cd /tmp                                                                                                       && \
-       cd arpack-ng                                                                                                  && \
-       git status                                                                                                    && \
-       git log -2                                                                                                    && \
-       sed -e 's/LOG_FLAGS = /LOG_FLAGS = --allow-run-as-root --oversubscribe /' -i PARPACK/EXAMPLES/MPI/Makefile.am && \
-       sed -e 's/LOG_FLAGS = /LOG_FLAGS = --allow-run-as-root --oversubscribe /' -i PARPACK/TESTS/MPI/Makefile.am    && \
-       ./bootstrap                                                                                                   && \
-       export FFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                                && \
-       export FCFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                               && \
-       export LIBS='-Wl,--no-as-needed -L/usr/lib/x86_64-linux-gnu -lmkl_sequential -lmkl_core -lpthread -lm -ldl'   && \
-       export INTERFACE64=1                                                                                          && \
-       ./configure --with-blas=mkl_gf_ilp64 --with-lapack=mkl_gf_ilp64 --enable-mpi --enable-icb-exmm                   \
-                   --disable-dependency-tracking                                                                     && \
-       export VERBOSE=1                                                                                              && \
-       make all                                                                                                      && \
-       make check                                                                                                    && \
-       find . -name   test-suite.log | xargs tail -n 300"                                                               \
-      &&                                                                                                                \
-      sudo docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp                                                               \
-      &&                                                                                                                \
-      sudo docker start -a mobydick
+      export DEBIAN_FRONTEND=noninteractive                                                                       && \
+      apt-get -y install dialog                                                                                   && \
+      echo yes | apt-get -y install intel-mkl libmkl-dev                                                          && \
+      ./bootstrap                                                                                                 && \
+      export FFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                              && \
+      export FCFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                             && \
+      export LIBS='-Wl,--no-as-needed -L/usr/lib/x86_64-linux-gnu -lmkl_sequential -lmkl_core -lpthread -lm -ldl' && \
+      export INTERFACE64=1                                                                                        && \
+      ./configure --with-blas=mkl_gf_ilp64 --with-lapack=mkl_gf_ilp64 --enable-mpi --enable-icb-exmm              && \
+      export VERBOSE=1                                                                                            && \
+      make all                                                                                                    && \
+      make check                                                                                                  && \
   # fedora (released fedora with openmpi)
   - stage: fedora
-    dist: xenial
+    dist: bionic
     script: ./scripts/travis_fedora.sh setup openmpi latest
-
   # fedora (with gcc 10 and mpich)
   - stage: fedora
-    dist: xenial
+    dist: bionic
     script: ./scripts/travis_fedora.sh setup mpich rawhide
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,29 +133,20 @@ jobs:
   # bionic <=> test "recent" systems, with ICB
   - stage: bionic
     dist: bionic
-    script: |
-      ./bootstrap                           && \
-      ./configure --enable-icb --enable-mpi && \
-      export VERBOSE=1                      && \
-      make all                              && \
-      make check                            && \
+    script: ./bootstrap && ./configure --enable-icb --enable-mpi && export VERBOSE=1 && make all && make check
   - stage: bionic
     dist: bionic
-    script: |
-      apt-get -y install python3-minimal python3-pip python3-numpy                       && \
-      pip3 install numpy                                                                 && \
-      apt-get -y install wget                                                            && \
-      wget https://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.tar.gz && \
-      tar -xf boost_1_67_0.tar.gz && cd boost_1_67_0                                     && \
-      ./bootstrap.sh --with-libraries=python --with-python=/usr/bin/python3              && \
-      ./b2 install                                                                       && \
-      apt-get install locate                                                             && \
-      updatedb                                                                           && \
-      mkdir -p build && cd build                                                         && \
-      cmake -DEXAMPLES=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' ..         && \
-      export VERBOSE=1                                                                   && \
-      make all                                                                           && \
-      make test                                                                          && \
+    before_install:
+    - apt-get -y install python3-minimal python3-pip python3-numpy
+    - pip3 install numpy
+    - apt-get -y install wget
+    - wget https://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.tar.gz
+    - tar -xf boost_1_67_0.tar.gz && cd boost_1_67_0
+    - ./bootstrap.sh --with-libraries=python --with-python=/usr/bin/python3
+    - ./b2 install
+    - apt-get install locate
+    - updatedb
+    script: mkdir -p build && cd build && cmake -DEXAMPLES=ON -DICB=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' .. && export VERBOSE=1 && make all && make test
   # bionic <=> coverage: "recent" systems with ICB
   - stage: coverage
     dist: bionic
@@ -182,10 +173,11 @@ jobs:
   # bionic <=> interface64: "recent" systems with ICB + MKL + ILP64
   - stage: interface64
     dist: bionic
+    before_install:
+    - export DEBIAN_FRONTEND=noninteractive
+    - apt-get -y install dialog
+    - echo yes | apt-get -y install intel-mkl libmkl-dev
     script: |
-      export DEBIAN_FRONTEND=noninteractive                                                                       && \
-      apt-get -y install dialog                                                                                   && \
-      echo yes | apt-get -y install intel-mkl libmkl-dev                                                          && \
       ./bootstrap                                                                                                 && \
       export FFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                              && \
       export FCFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                             && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,15 +137,16 @@ jobs:
   - stage: bionic
     dist: bionic
     before_install:
-    - apt-get -y install python3-minimal python3-pip python3-numpy
-    - pip3 install numpy
-    - apt-get -y install wget
+    - sudo apt-get -y install python3-minimal python3-pip python3-numpy
+    - sudo pip3 install --system numpy
+    # need to build boost-python from source for python 3 (repository package is built for python 2)
+    - sudo apt-get -y install wget
     - wget https://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.tar.gz
     - tar -xf boost_1_67_0.tar.gz && cd boost_1_67_0
     - ./bootstrap.sh --with-libraries=python --with-python=/usr/bin/python3
-    - ./b2 install
-    - apt-get install locate
-    - updatedb
+    - sudo ./b2 install
+    - sudo apt-get install locate
+    - sudo updatedb
     script: mkdir -p build && cd build && cmake -DEXAMPLES=ON -DICB=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' .. && export VERBOSE=1 && make all && make test
   # bionic <=> coverage: "recent" systems with ICB
   - stage: coverage
@@ -175,8 +176,8 @@ jobs:
     dist: bionic
     before_install:
     - export DEBIAN_FRONTEND=noninteractive
-    - apt-get -y install dialog
-    - echo yes | apt-get -y install intel-mkl libmkl-dev
+    - sudo apt-get -y install dialog
+    - echo yes | sudo apt-get -y install intel-mkl libmkl-dev
     script: |
       ./bootstrap                                                                                                 && \
       export FFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                              && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,9 +159,9 @@ jobs:
       cd $TRAVIS_BUILD_DIR && mkdir -p build && cd build &&                                  \
       cmake -DEXAMPLES=ON -DICB=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' .. && \
       export VERBOSE=1 && make all && make test
-  # bionic <=> coverage: "recent" systems with ICB
+  # xenial <=> coverage: "recent" systems with ICB
   - stage: coverage
-    dist: bionic
+    dist: xenial
     script: |
       mkdir -p build && cd build                                                   \
       &&                                                                           \

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,7 +159,7 @@ jobs:
       cd $TRAVIS_BUILD_DIR && mkdir -p build && cd build &&                                  \
       cmake -DEXAMPLES=ON -DICB=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' .. && \
       export VERBOSE=1 && make all && make test
-  # xenial <=> coverage: "recent" systems with ICB
+  # coverage: "recent" systems with ICB
   - stage: coverage
     dist: xenial
     script: |
@@ -182,37 +182,55 @@ jobs:
       head -n 50 coveralls.log && tail -n 50 coveralls.log                         \
       &&                                                                           \
       head -n 50 coveralls.json && tail -n 50 coveralls.json
-  # bionic <=> interface64: "recent" systems with ICB + MKL + ILP64
+  # interface64: "recent" systems with ICB + MKL + ILP64 (need debian/testing to get MKL-ILP64)
+  #   note: when you PR, docker-cp provides, in the container, the branch associated with the PR (not master where there's nothing new)
+  #         1. docker create --name mobydick IMAGE CMD        <=> create a container (= instance of image) but container is NOT yet started
+  #         2. docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp <=> copy git repository (CI worker, checkout-ed on PR branch) into the container
+  #                                                               note: docker-cp works only if copy from/to containers (not images)
+  #         3. docker start -a mobydick                       <=> start to run the container (initialized with docker-cp)
   - stage: interface64
-    dist: bionic
-    before_install:
-    - export DEBIAN_FRONTEND=noninteractive
-    - sudo apt-get -y update
-    - sudo apt-get -y install dialog
-    - echo yes | sudo apt-get -y install intel-mkl libmkl-dev
+    dist: xenial
     script: |
-      ./bootstrap                                                                                                 && \
-      export FFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                              && \
-      export FCFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                             && \
-      export LIBS='-Wl,--no-as-needed -L/usr/lib/x86_64-linux-gnu -lmkl_sequential -lmkl_core -lpthread -lm -ldl' && \
-      export INTERFACE64=1                                                                                        && \
-      ./configure --with-blas=mkl_gf_ilp64 --with-lapack=mkl_gf_ilp64 --enable-mpi --enable-icb-exmm              && \
-      export VERBOSE=1                                                                                            && \
-      make all                                                                                                    && \
-      make check                                                                                                  && \
-  - stage: interface64
-    dist: bionic
-    before_install:
-    - export DEBIAN_FRONTEND=noninteractive
-    - sudo apt-get -y update
-    - sudo apt-get -y install dialog
-    - echo yes | sudo apt-get -y install intel-mkl libmkl-dev
-    script: |
-      mkdir -p build && cd build                                                                   && \
-      BLA_VENDOR='Intel10_64ilp_seq' cmake -DINTERFACE64=ON -DEXAMPLES=ON -DICBEXMM=ON -DMPI=ON .. && \
-      export VERBOSE=1                                                                             && \
-      make all                                                                                     && \
-      make check                                                                                   && \
+      sudo docker pull debian                                                                                           \
+      &&                                                                                                                \
+      sudo docker create --name mobydick debian /bin/bash -c                                                            \
+      "cat /etc/os-release                                                                                           && \
+       cat /etc/apt/sources.list                                                                                     && \
+       sed -e 's/stretch/testing/'            -i /etc/apt/sources.list                                               && \
+       sed -e 's/main/main non-free contrib/' -i /etc/apt/sources.list                                               && \
+       sed -e '/security.debian.org/d'        -i /etc/apt/sources.list                                               && \
+       cat /etc/apt/sources.list                                                                                     && \
+       export DEBIAN_FRONTEND=noninteractive                                                                         && \
+       apt-get -y                                                                 update                             && \
+       apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef      upgrade                            && \
+       apt-get -y --allow-unauthenticated -o Dpkg::Options::=--force-confdef dist-upgrade                            && \
+       cat /etc/os-release                                                                                           && \
+       apt-get -y install dialog                                                                                     && \
+       echo yes | apt-get -y install intel-mkl libmkl-dev                                                            && \
+       apt-get -y install build-essential                                                                            && \
+       apt-get -y install git gfortran gcc g++ openmpi-bin libopenmpi-dev automake autoconf libtool pkg-config       && \
+       apt-get -y install libeigen3-dev                                                                              && \
+       cd /tmp                                                                                                       && \
+       cd arpack-ng                                                                                                  && \
+       git status                                                                                                    && \
+       git log -2                                                                                                    && \
+       sed -e 's/LOG_FLAGS = /LOG_FLAGS = --allow-run-as-root --oversubscribe /' -i PARPACK/EXAMPLES/MPI/Makefile.am && \
+       sed -e 's/LOG_FLAGS = /LOG_FLAGS = --allow-run-as-root --oversubscribe /' -i PARPACK/TESTS/MPI/Makefile.am    && \
+       ./bootstrap                                                                                                   && \
+       export FFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                                && \
+       export FCFLAGS='-DMKL_ILP64 -I/usr/include/mkl'                                                               && \
+       export LIBS='-Wl,--no-as-needed -L/usr/lib/x86_64-linux-gnu -lmkl_sequential -lmkl_core -lpthread -lm -ldl'   && \
+       export INTERFACE64=1                                                                                          && \
+       ./configure --with-blas=mkl_gf_ilp64 --with-lapack=mkl_gf_ilp64 --enable-mpi --enable-icb-exmm                   \
+                   --disable-dependency-tracking                                                                     && \
+       export VERBOSE=1                                                                                              && \
+       make all                                                                                                      && \
+       make check                                                                                                    && \
+       find . -name test-suite.log | xargs tail -n 300"                                                                 \
+      &&                                                                                                                \
+      sudo docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp                                                               \
+      &&                                                                                                                \
+      sudo docker start -a mobydick
 
 after_failure:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -187,6 +187,7 @@ jobs:
     dist: bionic
     before_install:
     - export DEBIAN_FRONTEND=noninteractive
+    - sudo apt-get -y update
     - sudo apt-get -y install dialog
     - echo yes | sudo apt-get -y install intel-mkl libmkl-dev
     script: |
@@ -203,6 +204,7 @@ jobs:
     dist: bionic
     before_install:
     - export DEBIAN_FRONTEND=noninteractive
+    - sudo apt-get -y update
     - sudo apt-get -y install dialog
     - echo yes | sudo apt-get -y install intel-mkl libmkl-dev
     script: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,14 @@ stages:
 
 jobs:
   include:
+  # fedora (released fedora with openmpi)
+  - stage: fedora
+    dist: bionic
+    script: ./scripts/travis_fedora.sh setup openmpi latest
+  # fedora (with gcc 10 and mpich)
+  - stage: fedora
+    dist: bionic
+    script: ./scripts/travis_fedora.sh setup mpich rawhide
   # osx <=> macOS 10.13 (high sierra)
   - stage: osx
     os: osx
@@ -188,14 +196,6 @@ jobs:
       export VERBOSE=1                                                                                            && \
       make all                                                                                                    && \
       make check                                                                                                  && \
-  # fedora (released fedora with openmpi)
-  - stage: fedora
-    dist: bionic
-    script: ./scripts/travis_fedora.sh setup openmpi latest
-  # fedora (with gcc 10 and mpich)
-  - stage: fedora
-    dist: bionic
-    script: ./scripts/travis_fedora.sh setup mpich rawhide
 
 after_failure:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -196,6 +196,18 @@ jobs:
       export VERBOSE=1                                                                                            && \
       make all                                                                                                    && \
       make check                                                                                                  && \
+  - stage: interface64
+    dist: bionic
+    before_install:
+    - export DEBIAN_FRONTEND=noninteractive
+    - sudo apt-get -y install dialog
+    - echo yes | sudo apt-get -y install intel-mkl libmkl-dev
+    script: |
+      mkdir -p build && cd build                                                                   && \
+      BLA_VENDOR='Intel10_64ilp_seq' cmake -DINTERFACE64=ON -DEXAMPLES=ON -DICBEXMM=ON -DMPI=ON .. && \
+      export VERBOSE=1                                                                             && \
+      make all                                                                                     && \
+      make check                                                                                   && \
 
 after_failure:
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ Important Features:
     $ export INTERFACE64=1
     $ ./configure --with-blas=mkl_gf_ilp64 --with-lapack=mkl_gf_ilp64
     $ make all check```
-    or
-    ```$ BLA_VENDOR='Intel10_64ilp_seq' cmake -DINTERFACE64=ON ..```
 * pyarpack: python support based on Boost.Python.Numpy exposing C++ API.
 
 This project started as a joint project between Debian, Octave and Scilab in order to

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Important Features:
     $ export INTERFACE64=1
     $ ./configure --with-blas=mkl_gf_ilp64 --with-lapack=mkl_gf_ilp64
     $ make all check```
+    or
+    ```$ BLA_VENDOR='Intel10_64ilp_seq' cmake -DINTERFACE64=ON ..```
 * pyarpack: python support based on Boost.Python.Numpy exposing C++ API.
 
 This project started as a joint project between Debian, Octave and Scilab in order to


### PR DESCRIPTION
## Pull request purpose

Fixing CI.
To test interface64, we need **I**LP64 blas/lapack : the only lib (I know available through CI) which provide them is intel-mkl. intel-mkl is available only in latest debian (but not in "old" ubuntu boxes last time I checked) : need docker+debian => apt-get update / upgrade may change packages !...

Don't remember why `apt-utils` was needed, but, if I added it at the time, there was a reason ! :D Hope it's not needed anymore (would make this a fix quick)