### PR TITLE
TravisCI: try to fix KO builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,8 @@ jobs:
     script: |
       sudo docker pull opensuse/tumbleweed                                                   \
       &&                                                                                     \
-      sudo docker create --name mobydick opensuse/tumbleweed /bin/bash -c                    \
+      sudo docker create --security-opt seccomp:unconfined                                   \
+                         --name mobydick opensuse/tumbleweed /bin/bash -c                    \
       "zypper ref                                                                         && \
        zypper update                                                                      && \
        zypper install -y git gcc gcc-fortran gcc-c++ openmpi2-devel                       && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,9 @@ jobs:
       sudo docker pull opensuse/tumbleweed                                                   \
       &&                                                                                     \
       sudo docker create --name mobydick opensuse/tumbleweed /bin/bash -c                    \
-      "zypper install -y git gcc gcc-fortran gcc-c++ openmpi2-devel                       && \
+      "zypper ref                                                                         && \
+       zypper update                                                                      && \
+       zypper install -y git gcc gcc-fortran gcc-c++ openmpi2-devel                       && \
        zypper install -y cmake                                                            && \
        zypper install -y blas-devel lapack-devel                                          && \
        cd /tmp                                                                            && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ jobs:
       sudo docker create --name mobydick opensuse/tumbleweed /bin/bash -c                    \
       "zypper ref                                                                         && \
        zypper update                                                                      && \
+       zypper rm patterns-openSUSE-kvm_server patterns-server-kvm_tools                   && \
        zypper install -y git gcc gcc-fortran gcc-c++ openmpi2-devel                       && \
        zypper install -y cmake                                                            && \
        zypper install -y blas-devel lapack-devel                                          && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ services:
 stages:
   # order stages
   - name: opensuse
-  - name: centos
   - name: fedora
   - name: osx
   - name: ubuntu_precise
@@ -71,33 +70,6 @@ jobs:
       &&                                                                                     \
       sudo docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp                                    \
       &&                                                                                     \
-      sudo docker start -a mobydick
-  # centos: "recent" systems with ICB
-  - stage: centos
-    dist: bionic
-    script: |
-      sudo docker pull centos                                                  \
-      &&                                                                       \
-      sudo docker create --name mobydick centos /bin/bash -c                   \
-      "dnf install -y dnf-plugins-core epel-release                         && \
-       dnf upgrade -y                                                       && \
-       dnf config-manager --set-enabled PowerTools                          && \
-       dnf install -y git make gcc gcc-gfortran gcc-c++ environment-modules && \
-       dnf install -y cmake                                                 && \
-       dnf install -y mpich-devel                                           && \
-       dnf --enablerepo=\"epel\" install -y openblas-devel lapack-devel     && \
-       . /etc/profile.d/modules.sh                                          && \
-       module avail && module load mpi && module list                       && \
-       cd /tmp                                                              && \
-       cd arpack-ng                                                         && \
-       git status                                                           && \
-       git log -2                                                           && \
-       mkdir -p build && cd build                                           && \
-       cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON ..                             && \
-       make all && make test"                                                  \
-      &&                                                                       \
-      sudo docker cp -a ${TRAVIS_BUILD_DIR} mobydick:/tmp                      \
-      &&                                                                       \
       sudo docker start -a mobydick
   # fedora (released fedora with openmpi)
   - stage: fedora

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ jobs:
     - brew list gcc      || brew install gcc
     - brew list autoconf || brew install autoconf
     - brew list automake || brew install automake
+    - brew list libtool  || brew install libtool
     - brew list mpich    || brew install mpich
     - brew list -1 | while read line; do brew link --overwrite $line; done;
     - softwareupdate --install -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ jobs:
       sudo docker create --name mobydick opensuse/tumbleweed /bin/bash -c                    \
       "zypper ref                                                                         && \
        zypper update                                                                      && \
-       zypper rm patterns-openSUSE-kvm_server patterns-server-kvm_tools                   && \
        zypper install -y git gcc gcc-fortran gcc-c++ openmpi2-devel                       && \
        zypper install -y cmake                                                            && \
        zypper install -y blas-devel lapack-devel                                          && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,9 +76,9 @@ jobs:
       sudo docker start -a mobydick
   # fedora (released fedora with openmpi)
   - stage: fedora
-    name: "Fedora latest with openmpi"
+    name: "Fedora rawhide with openmpi"
     dist: bionic
-    script: ./scripts/travis_fedora.sh setup openmpi latest
+    script: ./scripts/travis_fedora.sh setup openmpi rawhide
   # fedora (with gcc 10 and mpich)
   - stage: fedora
     name: "Fedora rawhide with mpich"


### PR DESCRIPTION
## Pull request purpose

CentOS dead : CI KO (docker image dropped ?...).
https://arstechnica.com/gadgets/2020/12/centos-linux-is-gone-but-its-refugees-have-alternatives/

