### PR TITLE
add C99 standard checking to `CMakeLists.txt` & minimum CMake version changed to CMake3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 arpack-ng - 3.9.0
 
+[ Haoyang Liu ]
+ * CMake: minimum required version changed to 3.0
+ * CMake: add C99 standard checking
+
 [ Robert Schütz ]
  * use CMAKE_INSTALL_FULL_<dir> in arpack.pc
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.6)
+cmake_minimum_required(VERSION 3.0)
 
 if (NOT DEFINED CMAKE_BUILD_TYPE)
    set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
@@ -12,6 +12,10 @@ set(arpack_ng_PATCH_VERSION 0)
 set(arpack_ng_VERSION ${arpack_ng_MAJOR_VERSION}.${arpack_ng_MINOR_VERSION}.${arpack_ng_PATCH_VERSION})
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
+
+# set C99 standard
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED True)
 
 # Adopted from https://github.com/feymark/arpack.git
 


### PR DESCRIPTION
older compilers may not enable this by default.

## Pull request purpose

- fix the comment in https://github.com/opencollab/arpack-ng/issues/297
- `add_library( ... INTERFACE ...)` is not supported in cmake 2
