### PR TITLE
Fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,15 @@ addons:
       - diffutils
       - findutils
       - libeigen3-dev
+  homebrew:
+    packages:
+      - gcc@10
+      - autoconf
+      - automake
+      - cmake
+      - lapack
+      - mpich
+    update: false
 
 services:
   - docker
@@ -32,8 +41,6 @@ before_script:
 
 stages:
   # order stages
-  - name: ubuntu_eoan
-  - name: ubuntu_groovy
   - name: osx
   - name: opensuse
   - name: centos
@@ -42,7 +49,9 @@ stages:
   - name: ubuntu_trusty
   - name: ubuntu_xenial
   - name: ubuntu_bionic
+  - name: ubuntu_eoan
   - name: ubuntu_focal
+  - name: ubuntu_groovy
   - name: coverage
   - name: debian_interface64
 
@@ -132,19 +141,16 @@ jobs:
   - stage: osx
     os: osx
     osx_image: xcode12
-    before_install:
-    - brew list --formula -1 | while read line; do brew unlink $line; done;
-    - brew list gcc      || brew install gcc@10
-    - brew list cmake    || brew install cmake
-    - brew list lapack   || brew install lapack
-    - brew list mpich    || brew install mpich
-    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+    before_script:
     - export CC=gcc-10
     - export CXX=g++-10
     - mpicc -show
+    # manually fix a bug in cmake + osx
+    # this line should be removed when cmake officially fixes it
     - sed -i '' 's/pi\[ce\]/pi[ce]|ramework/' $(brew --prefix cmake)/share/cmake/Modules/FindMPI.cmake
-    # full build and testing with openblas and lapack
-    # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
+    # full build and testing with blas and lapack
+    # note: -ff2c and -fno-second-underscore are NOT needed when using generic
+    # blas/lapack
     script: |
       mkdir -p build && cd build && cmake -DBLA_VENDOR=Generic -DCMAKE_PREFIX_PATH=$(brew --prefix lapack) -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
   #- stage: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,8 @@ jobs:
     before_install:
     - brew list -1 | while read line; do brew unlink $line; done;
     - brew list arpack   || brew install arpack # Test osx formula
-    - brew list -1 | while read line; do brew link --overwrite $line; done;
+    # note: brew has updated itself so we must add --formula to only list formulae
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     script: ls # Need fake script.
   - stage: osx
     os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,13 +136,12 @@ jobs:
     - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     - export CC=gcc-10
     - export CXX=g++-10
-    - export DYLD_LIBRARY_PATH=$(brew --prefix lapack):${DYLD_LIBRARY_PATH}
     - mpicc -show
     - sed -i '' 's/pi\[ce\]/pi[ce]|ramework/' $(brew --prefix cmake)/share/cmake/Modules/FindMPI.cmake
     # full build and testing with openblas and lapack
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
     script: |
-      mkdir -p build && cd build && FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DBLA_VENDOR=Generic -DCMAKE_PREFIX_PATH=$(brew --prefix lapack) -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
+      mkdir -p build && cd build && cmake -DBLA_VENDOR=Generic -DCMAKE_PREFIX_PATH=$(brew --prefix lapack) -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
   #- stage: osx
   #  os: osx
   #  osx_image: xcode11

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,20 +111,20 @@ jobs:
     dist: bionic
     script: ./scripts/travis_fedora.sh setup mpich rawhide
   # osx
-  - stage: osx
-    os: osx
-    osx_image: xcode12
-    before_install:
-    - brew list --formula -1 | while read line; do brew unlink $line; done;
-    - brew list gcc      || brew install gcc
-    - brew list autoconf || brew install autoconf
-    - brew list automake || brew install automake
-    - brew list mpich    || brew install mpich
-    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-    # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
-    # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
-    script: |
-      ./bootstrap && LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" ./configure --enable-icb --enable-mpi && make VERBOSE=1 && make check
+  #- stage: osx
+  #  os: osx
+  #  osx_image: xcode12
+  #  before_install:
+  #  - brew list --formula -1 | while read line; do brew unlink $line; done;
+  #  - brew list gcc      || brew install gcc
+  #  - brew list autoconf || brew install autoconf
+  #  - brew list automake || brew install automake
+  #  - brew list mpich    || brew install mpich
+  #  - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+  #  # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
+  #  # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
+  #  script: |
+  #    ./bootstrap && LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" ./configure --enable-icb --enable-mpi && make VERBOSE=1 && make check
   - stage: osx
     os: osx
     osx_image: xcode12
@@ -133,35 +133,35 @@ jobs:
     - brew list gcc      || brew install gcc@10
     - brew list cmake    || brew install cmake
     - brew list lapack   || brew install lapack
-    - brew list mpich    || brew install mpich
+    - brew list open-mpi || brew install open-mpi
     - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     - export CC=gcc-10
     - export CXX=g++-10
     - mpicc -show
     # manually fix a bug in cmake + osx
     # this line should be removed when cmake officially fixes it
-    - sed -i '' 's/pi\[ce\]/pi[ce]|ramework/' $(brew --prefix cmake)/share/cmake/Modules/FindMPI.cmake
+    #- sed -i '' 's/pi\[ce\]/pi[ce]|ramework/' $(brew --prefix cmake)/share/cmake/Modules/FindMPI.cmake
     # full build and testing with blas and lapack
     # note: -ff2c and -fno-second-underscore are NOT needed when using generic
     # blas/lapack
     script: |
       mkdir -p build && cd build && cmake -DBLA_VENDOR=Generic -DCMAKE_PREFIX_PATH=$(brew --prefix lapack) -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
-  - stage: osx
-    os: osx
-    osx_image: xcode11
-    before_install:
-    - brew list --formula -1 | while read line; do brew unlink $line; done;
-    - brew list arpack   || brew install arpack # Test osx formula
-    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-    script: ls # Need fake script.
-  - stage: osx
-    os: osx
-    osx_image: xcode12
-    before_install:
-    - brew list --formula -1 | while read line; do brew unlink $line; done;
-    - brew list arpack   || brew install arpack # Test osx formula
-    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-    script: ls # Need fake script.
+  #- stage: osx
+  #  os: osx
+  #  osx_image: xcode11
+  #  before_install:
+  #  - brew list -1 | while read line; do brew unlink $line; done;
+  #  - brew list arpack   || brew install arpack # Test osx formula
+  #  - brew list -1 | while read line; do brew link --overwrite $line; done;
+  #  script: ls # Need fake script.
+  #- stage: osx
+  #  os: osx
+  #  osx_image: xcode12
+  #  before_install:
+  #  - brew list --formula -1 | while read line; do brew unlink $line; done;
+  #  - brew list arpack   || brew install arpack # Test osx formula
+  #  - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+  #  script: ls # Need fake script.
   # ubuntu_precise <=> test "older" systems, without ICB, without cmake (too old to be supported)
   - stage: ubuntu_precise
     dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,56 +109,56 @@ jobs:
     dist: bionic
     script: ./scripts/travis_fedora.sh setup mpich rawhide
   # osx
+  #- stage: osx
+  #  os: osx
+  #  osx_image: xcode12
+  #  before_install:
+  #  - brew list --formula -1 | while read line; do brew unlink $line; done;
+  #  - brew list gcc      || brew install gcc
+  #  - brew list autoconf || brew install autoconf
+  #  - brew list automake || brew install automake
+  #  - brew list mpich    || brew install mpich
+  #  - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+  #  - softwareupdate --install -a
+  #  # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
+  #  # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
+  #  script: |
+  #    ./bootstrap && LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" ./configure --enable-icb --enable-mpi && make VERBOSE=1 && make check
   - stage: osx
     os: osx
     osx_image: xcode12
     before_install:
     - brew list --formula -1 | while read line; do brew unlink $line; done;
-    - brew list gcc      || brew install gcc
-    - brew list autoconf || brew install autoconf
-    - brew list automake || brew install automake
-    - brew list mpich    || brew install mpich
-    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-    - softwareupdate --install -a
-    # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
-    # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
-    script: |
-      ./bootstrap && LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" ./configure --enable-icb --enable-mpi && make VERBOSE=1 && make check
-  - stage: osx
-    os: osx
-    osx_image: xcode12
-    before_install:
-    - brew list --formula -1 | while read line; do brew unlink $line; done;
-    - brew list gcc      || brew install gcc
+    - brew list gcc      || brew install gcc@10
     - brew list cmake    || brew install cmake
     - brew list openblas || brew install openblas
+    - brew list lapack   || brew install lapack
     - brew list mpich    || brew install mpich
     - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-    - test -n $CC && unset CC
-    - test -n $CXX && unset CXX
+    - export CC=gcc-10
+    - export CXX=g++-10
     - mpicc -show
     - sed -i '' 's/pi\[ce\]/pi[ce]|ramework/' $(brew --prefix cmake)/share/cmake/Modules/FindMPI.cmake
-    - cat $(brew --prefix cmake)/share/cmake/Modules/FindMPI.cmake | grep ramework
     # full build and testing with openblas and lapack
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
     script: |
-      mkdir -p build && cd build && LDFLAGS="-L/usr/local/opt/openblas/lib" CPPFLAGS="-I/usr/local/opt/openblas/include" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/openblas -DBLA_VENDOR=OpenBLAS -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
-  - stage: osx
-    os: osx
-    osx_image: xcode11
-    before_install:
-    - brew list --formula -1 | while read line; do brew unlink $line; done;
-    - brew list arpack   || brew install arpack # Test osx formula
-    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-    script: ls # Need fake script.
-  - stage: osx
-    os: osx
-    osx_image: xcode12
-    before_install:
-    - brew list --formula -1 | while read line; do brew unlink $line; done;
-    - brew list arpack   || brew install arpack # Test osx formula
-    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-    script: ls # Need fake script.
+      mkdir -p build && cd build && LDFLAGS="-L/usr/local/opt/openblas/lib -L/usr/local/opt/lapack/lib" CPPFLAGS="-I/usr/local/opt/openblas/include -I/usr/local/opt/lapack/include" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DCMAKE_PREFIX_PATH="/usr/local/opt/openblas;/usr/local/opt/lapack" -DBLA_VENDOR=OpenBLAS -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
+  #- stage: osx
+  #  os: osx
+  #  osx_image: xcode11
+  #  before_install:
+  #  - brew list --formula -1 | while read line; do brew unlink $line; done;
+  #  - brew list arpack   || brew install arpack # Test osx formula
+  #  - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+  #  script: ls # Need fake script.
+  #- stage: osx
+  #  os: osx
+  #  osx_image: xcode12
+  #  before_install:
+  #  - brew list --formula -1 | while read line; do brew unlink $line; done;
+  #  - brew list arpack   || brew install arpack # Test osx formula
+  #  - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+  #  script: ls # Need fake script.
   # ubuntu_precise <=> test "older" systems, without ICB, without cmake (too old to be supported)
   - stage: ubuntu_precise
     dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,6 @@ addons:
       - diffutils
       - findutils
       - libeigen3-dev
-  homebrew:
-    packages:
-      - gcc@10
-      - autoconf
-      - automake
-      - cmake
-      - lapack
-      - mpich
-    update: false
 
 services:
   - docker
@@ -126,6 +117,13 @@ jobs:
   - stage: osx
     os: osx
     osx_image: xcode12
+    before_install:
+    - brew list --formula -1 | while read line; do brew unlink $line; done;
+    - brew list gcc      || brew install gcc
+    - brew list autoconf || brew install autoconf
+    - brew list automake || brew install automake
+    - brew list mpich    || brew install mpich
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
     script: |
@@ -133,7 +131,13 @@ jobs:
   - stage: osx
     os: osx
     osx_image: xcode12
-    before_script:
+    before_install:
+    - brew list --formula -1 | while read line; do brew unlink $line; done;
+    - brew list gcc      || brew install gcc@10
+    - brew list cmake    || brew install cmake
+    - brew list lapack   || brew install lapack
+    - brew list mpich    || brew install mpich
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     - export CC=gcc-10
     - export CXX=g++-10
     - mpicc -show

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,17 +131,18 @@ jobs:
     - brew list --formula -1 | while read line; do brew unlink $line; done;
     - brew list gcc      || brew install gcc@10
     - brew list cmake    || brew install cmake
-    - brew list openblas || brew install openblas
+    - brew list lapack   || brew install lapack
     - brew list mpich    || brew install mpich
     - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     - export CC=gcc-10
     - export CXX=g++-10
+    - export DYLD_LIBRARY_PATH=$(brew --prefix lapack):${DYLD_LIBRARY_PATH}
     - mpicc -show
     - sed -i '' 's/pi\[ce\]/pi[ce]|ramework/' $(brew --prefix cmake)/share/cmake/Modules/FindMPI.cmake
     # full build and testing with openblas and lapack
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
     script: |
-      mkdir -p build && cd build && FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
+      mkdir -p build && cd build && FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DBLA_VENDOR=Generic -DCMAKE_PREFIX_PATH=$(brew --prefix lapack) -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
   #- stage: osx
   #  os: osx
   #  osx_image: xcode11

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ jobs:
       sudo docker create --name mobydick centos /bin/bash -c                   \
       "dnf install -y dnf-plugins-core epel-release                         && \
        dnf upgrade -y                                                       && \
-       dnf config-manager --set-enabled PowerTools                          && \
+       dnf config-manager --set-enabled powertools                          && \
        dnf install -y git make gcc gcc-gfortran gcc-c++ environment-modules && \
        dnf install -y cmake                                                 && \
        dnf install -y mpich-devel                                           && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ addons:
 services:
   - docker
 
-before_script:
-  - if [ $TRAVIS_OS_NAME = linux ]; then echo de4bc63e-edf4-4749-9581-f5fba3536b8f | docker login -u ryanbernx --password-stdin || true; fi
-
 stages:
   # order stages
   - name: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ services:
   - docker
 
 before_script:
-  - if [ $TRAVIS_OS_NAME = linux ]; then echo de4bc63e-edf4-4749-9581-f5fba3536b8f | docker login -u ryanbernx --password-stdin; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; then echo de4bc63e-edf4-4749-9581-f5fba3536b8f | docker login -u ryanbernx --password-stdin || true; fi
 
 stages:
   # order stages
@@ -123,21 +123,13 @@ jobs:
     dist: bionic
     script: ./scripts/travis_fedora.sh setup mpich rawhide
   # osx
-  #- stage: osx
-  #  os: osx
-  #  osx_image: xcode12
-  #  before_install:
-  #  - brew list --formula -1 | while read line; do brew unlink $line; done;
-  #  - brew list gcc      || brew install gcc
-  #  - brew list autoconf || brew install autoconf
-  #  - brew list automake || brew install automake
-  #  - brew list mpich    || brew install mpich
-  #  - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-  #  - softwareupdate --install -a
-  #  # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
-  #  # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
-  #  script: |
-  #    ./bootstrap && LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" ./configure --enable-icb --enable-mpi && make VERBOSE=1 && make check
+  - stage: osx
+    os: osx
+    osx_image: xcode12
+    # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
+    # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
+    script: |
+      ./bootstrap && LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" ./configure --enable-icb --enable-mpi && make VERBOSE=1 && make check
   - stage: osx
     os: osx
     osx_image: xcode12
@@ -153,22 +145,22 @@ jobs:
     # blas/lapack
     script: |
       mkdir -p build && cd build && cmake -DBLA_VENDOR=Generic -DCMAKE_PREFIX_PATH=$(brew --prefix lapack) -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
-  #- stage: osx
-  #  os: osx
-  #  osx_image: xcode11
-  #  before_install:
-  #  - brew list --formula -1 | while read line; do brew unlink $line; done;
-  #  - brew list arpack   || brew install arpack # Test osx formula
-  #  - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-  #  script: ls # Need fake script.
-  #- stage: osx
-  #  os: osx
-  #  osx_image: xcode12
-  #  before_install:
-  #  - brew list --formula -1 | while read line; do brew unlink $line; done;
-  #  - brew list arpack   || brew install arpack # Test osx formula
-  #  - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-  #  script: ls # Need fake script.
+  - stage: osx
+    os: osx
+    osx_image: xcode11
+    before_install:
+    - brew list --formula -1 | while read line; do brew unlink $line; done;
+    - brew list arpack   || brew install arpack # Test osx formula
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+    script: ls # Need fake script.
+  - stage: osx
+    os: osx
+    osx_image: xcode12
+    before_install:
+    - brew list --formula -1 | while read line; do brew unlink $line; done;
+    - brew list arpack   || brew install arpack # Test osx formula
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+    script: ls # Need fake script.
   # ubuntu_precise <=> test "older" systems, without ICB, without cmake (too old to be supported)
   - stage: ubuntu_precise
     dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,12 +114,13 @@ jobs:
     os: osx
     osx_image: xcode12
     before_install:
-    - brew list -1 | while read line; do brew unlink $line; done;
+    - brew list --formula -1 | while read line; do brew unlink $line; done;
     - brew list gcc      || brew install gcc
     - brew list autoconf || brew install autoconf
     - brew list automake || brew install automake
     - brew list mpich    || brew install mpich
-    - brew list -1 | while read line; do brew link --overwrite $line; done;
+    - brew list --formula -1
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     - softwareupdate --install -a
     # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
@@ -129,13 +130,13 @@ jobs:
     os: osx
     osx_image: xcode12
     before_install:
-    - brew list -1 | while read line; do brew unlink $line; done;
+    - brew list --formula -1 | while read line; do brew unlink $line; done;
     - brew list gcc      || brew install gcc
     - brew list cmake    || brew install cmake
     - brew list openblas || brew install openblas
     - brew list lapack   || brew install lapack
     - brew list mpich    || brew install mpich
-    - brew list -1 | while read line; do brew link --overwrite $line; done;
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     # full build and testing with openblas and lapack
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
     script: |
@@ -144,18 +145,17 @@ jobs:
     os: osx
     osx_image: xcode11
     before_install:
-    - brew list -1 | while read line; do brew unlink $line; done;
+    - brew list --formula -1 | while read line; do brew unlink $line; done;
     - brew list arpack   || brew install arpack # Test osx formula
-    - brew list -1
-    - brew list -1 | while read line; do brew link --overwrite $line; done;
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     script: ls # Need fake script.
   - stage: osx
     os: osx
     osx_image: xcode12
     before_install:
-    - brew list -1 | while read line; do brew unlink $line; done;
+    - brew list --formula -1 | while read line; do brew unlink $line; done;
     - brew list arpack   || brew install arpack # Test osx formula
-    - brew list -1 | while read line; do brew link --overwrite $line; done;
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     script: ls # Need fake script.
   # ubuntu_precise <=> test "older" systems, without ICB, without cmake (too old to be supported)
   - stage: ubuntu_precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,14 @@ services:
 
 stages:
   # order stages
+  - name: osx
   - name: opensuse
   - name: centos
   - name: fedora
-  - name: osx
   - name: ubuntu_precise
   - name: ubuntu_trusty
   - name: ubuntu_xenial
   - name: ubuntu_bionic
-  - name: ubuntu_eoan
   - name: ubuntu_focal
   - name: coverage
   - name: debian_interface64
@@ -119,7 +118,6 @@ jobs:
     - brew list autoconf || brew install autoconf
     - brew list automake || brew install automake
     - brew list mpich    || brew install mpich
-    - brew list --formula -1
     - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     - softwareupdate --install -a
     # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
@@ -134,13 +132,15 @@ jobs:
     - brew list gcc      || brew install gcc
     - brew list cmake    || brew install cmake
     - brew list openblas || brew install openblas
-    - brew list lapack   || brew install lapack
     - brew list mpich    || brew install mpich
     - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+    - mpiexec --version
+    - gcc -v
+    - gfortran -v
     # full build and testing with openblas and lapack
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
     script: |
-      mkdir -p build && cd build && FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
+      mkdir -p build && cd build && LDFLAGS="-L/usr/local/opt/openblas/lib" CPPFLAGS="-I/usr/local/opt/openblas/include" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/openblas -DMPIEXEC_EXCUTABLE=`which mpiexec` -DBLA_VENDOR=OpenBLAS -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
   - stage: osx
     os: osx
     osx_image: xcode11
@@ -199,10 +199,6 @@ jobs:
       cd $TRAVIS_BUILD_DIR && mkdir -p build && cd build &&                                  \
       cmake -DEXAMPLES=ON -DICB=ON -DICBEXMM=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' .. && \
       export VERBOSE=1 && make all && make test
-  # ubuntu_eoan <=> test "recent" systems, with ICB
-  - stage: ubuntu_eoan
-    dist: bionic
-    script: ./scripts/travis_ubuntu.sh ubuntu :eoan
   # ubuntu_focal <=> test "recent" systems, with ICB
   - stage: ubuntu_focal
     dist: bionic
@@ -287,3 +283,5 @@ after_failure:
   - if [[ -f $TRAVIS_BUILD_DIR/build/Testing/Temporary/LastTest.log ]]; then tail -n 300 $TRAVIS_BUILD_DIR/build/Testing/Temporary/LastTest.log; fi
   - find . -name test-suite.log | xargs tail -n 300
   - find . -name arpackmm.run.log | xargs tail -n 300
+  - find . -name CMakeOutput.log | xargs cat
+  - find . -name CMakeError.log | xargs cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,13 @@ addons:
 services:
   - docker
 
+before_script:
+  - if [ $TRAVIS_OS_NAME = linux ]; then echo de4bc63e-edf4-4749-9581-f5fba3536b8f | docker login -u ryanbernx --password-stdin; fi
+
 stages:
   # order stages
+  - name: ubuntu_eoan
+  - name: ubuntu_groovy
   - name: osx
   - name: opensuse
   - name: centos
@@ -200,10 +205,18 @@ jobs:
       cd $TRAVIS_BUILD_DIR && mkdir -p build && cd build &&                                  \
       cmake -DEXAMPLES=ON -DICB=ON -DICBEXMM=ON -DMPI=ON -DPYTHON3=ON -DBOOST_PYTHON_LIBSUFFIX='36' .. && \
       export VERBOSE=1 && make all && make test
+  # ubuntu_eoan <=> test "recent EOL" systems, with ICB
+  - stage: ubuntu_eoan
+    dist: bionic
+    script: ./scripts/travis_ubuntu.sh ubuntu :eoan old
   # ubuntu_focal <=> test "recent" systems, with ICB
   - stage: ubuntu_focal
     dist: bionic
     script: ./scripts/travis_ubuntu.sh ubuntu :focal
+  # ubuntu_groovy <=> test "recent non-LTS" systems, with ICB
+  - stage: ubuntu_groovy
+    dist: bionic
+    script: ./scripts/travis_ubuntu.sh ubuntu :groovy
   # coverage: "recent" systems with ICB
   - stage: coverage
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,11 @@ jobs:
   #                                                               note: docker-cp works only if copy from/to containers (not images)
   #         3. docker start -a mobydick                       <=> start to run the container (initialized with docker-cp)
   - stage: opensuse
-    dist: focal
+    dist: bionic
     script: |
       sudo docker pull opensuse/tumbleweed                                                   \
       &&                                                                                     \
-      sudo docker create --name mobydick opensuse/tumbleweed /bin/bash -c                    \
+      sudo docker create --security-opt seccomp:unconfined --name mobydick opensuse/tumbleweed /bin/bash -c                    \
       "zypper install -y git gcc gcc-fortran gcc-c++ openmpi2-devel                       && \
        zypper install -y cmake                                                            && \
        zypper install -y blas-devel lapack-devel                                          && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,6 @@ jobs:
     - brew list gcc      || brew install gcc@10
     - brew list cmake    || brew install cmake
     - brew list openblas || brew install openblas
-    - brew list lapack   || brew install lapack
     - brew list mpich    || brew install mpich
     - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     - export CC=gcc-10
@@ -142,7 +141,7 @@ jobs:
     # full build and testing with openblas and lapack
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
     script: |
-      mkdir -p build && cd build && LDFLAGS="-L/usr/local/opt/openblas/lib -L/usr/local/opt/lapack/lib" CPPFLAGS="-I/usr/local/opt/openblas/include -I/usr/local/opt/lapack/include" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DCMAKE_PREFIX_PATH="/usr/local/opt/openblas;/usr/local/opt/lapack" -DBLA_VENDOR=OpenBLAS -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
+      mkdir -p build && cd build && FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
   #- stage: osx
   #  os: osx
   #  osx_image: xcode11

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,6 @@ jobs:
     - brew list autoconf || brew install autoconf
     - brew list automake || brew install automake
     - brew list mpich    || brew install mpich
-    - brew list xquartz  || brew install xquartz
     - brew list -1 | while read line; do brew link --overwrite $line; done;
     - softwareupdate --install -a
     # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
@@ -136,7 +135,6 @@ jobs:
     - brew list openblas || brew install openblas
     - brew list lapack   || brew install lapack
     - brew list mpich    || brew install mpich
-    - brew list xquartz  || brew install xquartz
     - brew list -1 | while read line; do brew link --overwrite $line; done;
     # full build and testing with openblas and lapack
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
@@ -148,7 +146,7 @@ jobs:
     before_install:
     - brew list -1 | while read line; do brew unlink $line; done;
     - brew list arpack   || brew install arpack # Test osx formula
-    - brew list xquartz  || brew install xquartz
+    - brew list -1
     - brew list -1 | while read line; do brew link --overwrite $line; done;
     script: ls # Need fake script.
   - stage: osx
@@ -157,7 +155,6 @@ jobs:
     before_install:
     - brew list -1 | while read line; do brew unlink $line; done;
     - brew list arpack   || brew install arpack # Test osx formula
-    - brew list xquartz  || brew install xquartz
     - brew list -1 | while read line; do brew link --overwrite $line; done;
     script: ls # Need fake script.
   # ubuntu_precise <=> test "older" systems, without ICB, without cmake (too old to be supported)

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,7 @@ jobs:
     - brew list autoconf || brew install autoconf
     - brew list automake || brew install automake
     - brew list mpich    || brew install mpich
+    - brew list xquartz  || brew install xquartz
     - brew list -1 | while read line; do brew link --overwrite $line; done;
     - softwareupdate --install -a
     # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
@@ -135,6 +136,7 @@ jobs:
     - brew list openblas || brew install openblas
     - brew list lapack   || brew install lapack
     - brew list mpich    || brew install mpich
+    - brew list xquartz  || brew install xquartz
     - brew list -1 | while read line; do brew link --overwrite $line; done;
     # full build and testing with openblas and lapack
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
@@ -146,6 +148,7 @@ jobs:
     before_install:
     - brew list -1 | while read line; do brew unlink $line; done;
     - brew list arpack   || brew install arpack # Test osx formula
+    - brew list xquartz  || brew install xquartz
     - brew list -1 | while read line; do brew link --overwrite $line; done;
     script: ls # Need fake script.
   - stage: osx
@@ -154,6 +157,7 @@ jobs:
     before_install:
     - brew list -1 | while read line; do brew unlink $line; done;
     - brew list arpack   || brew install arpack # Test osx formula
+    - brew list xquartz  || brew install xquartz
     - brew list -1 | while read line; do brew link --overwrite $line; done;
     script: ls # Need fake script.
   # ubuntu_precise <=> test "older" systems, without ICB, without cmake (too old to be supported)

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,13 +134,13 @@ jobs:
     - brew list openblas || brew install openblas
     - brew list mpich    || brew install mpich
     - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-    - mpiexec --version
-    - gcc -v
-    - gfortran -v
+    - test -n $CC && unset CC
+    - test -n $CXX && unset CXX
+    - mpicc -show
     # full build and testing with openblas and lapack
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
     script: |
-      mkdir -p build && cd build && LDFLAGS="-L/usr/local/opt/openblas/lib" CPPFLAGS="-I/usr/local/opt/openblas/include" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/openblas -DMPIEXEC_EXCUTABLE=`which mpiexec` -DBLA_VENDOR=OpenBLAS -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
+      mkdir -p build && cd build && LDFLAGS="-L/usr/local/opt/openblas/lib" CPPFLAGS="-I/usr/local/opt/openblas/include" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/openblas -DBLA_VENDOR=OpenBLAS -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
   - stage: osx
     os: osx
     osx_image: xcode11

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,20 +111,20 @@ jobs:
     dist: bionic
     script: ./scripts/travis_fedora.sh setup mpich rawhide
   # osx
-  #- stage: osx
-  #  os: osx
-  #  osx_image: xcode12
-  #  before_install:
-  #  - brew list --formula -1 | while read line; do brew unlink $line; done;
-  #  - brew list gcc      || brew install gcc
-  #  - brew list autoconf || brew install autoconf
-  #  - brew list automake || brew install automake
-  #  - brew list mpich    || brew install mpich
-  #  - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-  #  # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
-  #  # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
-  #  script: |
-  #    ./bootstrap && LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" ./configure --enable-icb --enable-mpi && make VERBOSE=1 && make check
+  - stage: osx
+    os: osx
+    osx_image: xcode12
+    before_install:
+    - brew list --formula -1 | while read line; do brew unlink $line; done;
+    - brew list gcc      || brew install gcc
+    - brew list autoconf || brew install autoconf
+    - brew list automake || brew install automake
+    - brew list mpich    || brew install mpich
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+    # full build and testing with Accelerate framework (xcode provides vecLib which stands for BLAS/LAPACK)
+    # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
+    script: |
+      ./bootstrap && LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" ./configure --enable-icb --enable-mpi && make VERBOSE=1 && make check
   - stage: osx
     os: osx
     osx_image: xcode12
@@ -133,35 +133,34 @@ jobs:
     - brew list gcc      || brew install gcc@10
     - brew list cmake    || brew install cmake
     - brew list lapack   || brew install lapack
+    # note: mpich not working due to a cmake bug
     - brew list open-mpi || brew install open-mpi
     - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
     - export CC=gcc-10
     - export CXX=g++-10
     - mpicc -show
-    # manually fix a bug in cmake + osx
-    # this line should be removed when cmake officially fixes it
-    #- sed -i '' 's/pi\[ce\]/pi[ce]|ramework/' $(brew --prefix cmake)/share/cmake/Modules/FindMPI.cmake
     # full build and testing with blas and lapack
     # note: -ff2c and -fno-second-underscore are NOT needed when using generic
     # blas/lapack
     script: |
       mkdir -p build && cd build && cmake -DBLA_VENDOR=Generic -DCMAKE_PREFIX_PATH=$(brew --prefix lapack) -DEXAMPLES=ON -DICB=ON -DMPI=ON .. && make VERBOSE=1 && make test
-  #- stage: osx
-  #  os: osx
-  #  osx_image: xcode11
-  #  before_install:
-  #  - brew list -1 | while read line; do brew unlink $line; done;
-  #  - brew list arpack   || brew install arpack # Test osx formula
-  #  - brew list -1 | while read line; do brew link --overwrite $line; done;
-  #  script: ls # Need fake script.
-  #- stage: osx
-  #  os: osx
-  #  osx_image: xcode12
-  #  before_install:
-  #  - brew list --formula -1 | while read line; do brew unlink $line; done;
-  #  - brew list arpack   || brew install arpack # Test osx formula
-  #  - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
-  #  script: ls # Need fake script.
+  - stage: osx
+    os: osx
+    osx_image: xcode11
+    # note: in xcode11 image, brew list only lists all formulae
+    before_install:
+    - brew list -1 | while read line; do brew unlink $line; done;
+    - brew list arpack   || brew install arpack # Test osx formula
+    - brew list -1 | while read line; do brew link --overwrite $line; done;
+    script: ls # Need fake script.
+  - stage: osx
+    os: osx
+    osx_image: xcode12
+    before_install:
+    - brew list --formula -1 | while read line; do brew unlink $line; done;
+    - brew list arpack   || brew install arpack # Test osx formula
+    - brew list --formula -1 | while read line; do brew link --overwrite $line; done;
+    script: ls # Need fake script.
   # ubuntu_precise <=> test "older" systems, without ICB, without cmake (too old to be supported)
   - stage: ubuntu_precise
     dist: precise
@@ -207,7 +206,7 @@ jobs:
   # ubuntu_eoan <=> test "recent EOL" systems, with ICB
   - stage: ubuntu_eoan
     dist: bionic
-    script: ./scripts/travis_ubuntu.sh ubuntu :eoan old
+    script: ./scripts/travis_ubuntu.sh ubuntu :eoan
   # ubuntu_focal <=> test "recent" systems, with ICB
   - stage: ubuntu_focal
     dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,8 @@ jobs:
     - test -n $CC && unset CC
     - test -n $CXX && unset CXX
     - mpicc -show
+    - sed -i '' 's/pi\[ce\]/pi[ce]|ramework/' $(brew --prefix cmake)/share/cmake/Modules/FindMPI.cmake
+    - cat $(brew --prefix cmake)/share/cmake/Modules/FindMPI.cmake | grep ramework
     # full build and testing with openblas and lapack
     # note: -ff2c to convert fortran code to C, -fno-second-underscore to force underscoring of external symbols to link
     script: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
   #                                                               note: docker-cp works only if copy from/to containers (not images)
   #         3. docker start -a mobydick                       <=> start to run the container (initialized with docker-cp)
   - stage: opensuse
-    dist: bionic
+    dist: focal
     script: |
       sudo docker pull opensuse/tumbleweed                                                   \
       &&                                                                                     \

--- a/scripts/travis_ubuntu.sh
+++ b/scripts/travis_ubuntu.sh
@@ -3,8 +3,9 @@
 ## -x be verbose; write what we are doing, as we do it
 set -ex
 
+# for non-LTS && EOL'ed ubuntu, the mirror url must be modified to run `apt update`
 cmd=ls
-if [ $3 = "old" ]; then
+if [ $2 = ":eoan" ]; then
     cmd="sed -i 's/\(security\|archive\).ubuntu/old-releases.ubuntu/g' /etc/apt/sources.list"
 fi 
 

--- a/scripts/travis_ubuntu.sh
+++ b/scripts/travis_ubuntu.sh
@@ -12,7 +12,7 @@ fi
 sudo docker pull "$1$2"                                                                                           \
 &&                                                                                                                \
 sudo docker create --name mobydick "$1$2" /bin/bash -c                                                            \
-"${cmd} &&
+"${cmd} && \
  apt-get    update                                                                                             && \
  ln -snf /usr/share/zoneinfo/Europe/Paris /etc/localtime && echo 'Europe/Paris' > /etc/timezone                && \
  apt-get -y install build-essential                                                                            && \

--- a/scripts/travis_ubuntu.sh
+++ b/scripts/travis_ubuntu.sh
@@ -13,7 +13,6 @@ sudo docker pull "$1$2"                                                         
 &&                                                                                                                \
 sudo docker create --name mobydick "$1$2" /bin/bash -c                                                            \
 "${cmd} &&
-                     \
  apt-get    update                                                                                             && \
  ln -snf /usr/share/zoneinfo/Europe/Paris /etc/localtime && echo 'Europe/Paris' > /etc/timezone                && \
  apt-get -y install build-essential                                                                            && \

--- a/scripts/travis_ubuntu.sh
+++ b/scripts/travis_ubuntu.sh
@@ -3,10 +3,17 @@
 ## -x be verbose; write what we are doing, as we do it
 set -ex
 
+cmd=ls
+if [ $3 = "old" ]; then
+    cmd="sed -i 's/\(security\|archive\).ubuntu/old-releases.ubuntu/g' /etc/apt/sources.list"
+fi 
+
 sudo docker pull "$1$2"                                                                                           \
 &&                                                                                                                \
 sudo docker create --name mobydick "$1$2" /bin/bash -c                                                            \
-"apt-get    update                                                                                             && \
+"${cmd} &&
+                     \
+ apt-get    update                                                                                             && \
  ln -snf /usr/share/zoneinfo/Europe/Paris /etc/localtime && echo 'Europe/Paris' > /etc/timezone                && \
  apt-get -y install build-essential                                                                            && \
  apt-get -y install dialog apt-utils                                                                           && \


### PR DESCRIPTION
## Pull request purpose

fix travis ci

## Detailed changes proposed in this pull request

- Add `--security-opt seccomp:unconfined` to stage: opensuse as suggested in https://www.reddit.com/r/openSUSE/comments/lm48zo/install_git_in_docker_tumbleweed/
- `centos-stream` renames `PowerTools` to `powertools`
- `brew link` only works for formulae, thus add `--formula` to `brew list`
- ubuntu eoan has reached EOL. The updates should be installed from  http://old-releases.ubuntu.com/ubuntu/
- Add build for ubuntu groovy
- A bug in cmake causes the build to fail on osx. Work around this issue by modifying `FindMPI.cmake`.
- Remove `-ff2c` `-fno_second_underscore` when compiling with generic `lapack` or `openblas`.

