### PR TITLE
Use @LIBSUFFIX@ in cmake file.

### DIFF
--- a/arpack-ng-config.cmake.in
+++ b/arpack-ng-config.cmake.in
@@ -20,6 +20,6 @@ set(includedir "@includedir@")
 # Create arpack targets.
 add_library(ARPACK::ARPACK INTERFACE IMPORTED)
 set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${includedir}/arpack")
-set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_LINK_LIBRARIES      "arpack")
+set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_LINK_LIBRARIES      "arpack@LIBSUFFIX@")
 add_library(PARPACK::PARPACK INTERFACE IMPORTED)
-set_target_properties(PARPACK::PARPACK PROPERTIES INTERFACE_LINK_LIBRARIES    "parpack")
+set_target_properties(PARPACK::PARPACK PROPERTIES INTERFACE_LINK_LIBRARIES    "parpack@LIBSUFFIX@")


### PR DESCRIPTION
## Pull request purpose

When building ARPACK with e.g. `LIBSUFFIX=_64`, the names of the installed libraries are e.g. `libarpack_64.so`. The library name in the `arpack-ng-config.cmake` file is `"arpack"` though. 
I might be misunderstanding how cmake works. But I think that the library name in that file should be `"arpack_64"` in that case.

## Detailed changes proposed in this pull request

Change the cmake file to include `LIBSUFFIX` for the library names.
