### PR TITLE
[CMake] Test find_package.

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -23,8 +23,10 @@ jobs:
           cd build
           cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON ..
           make all
-          make CTEST_OUTPUT_ON_FAILURE=1 test
+          make test
           make package_source
+        env:
+          CTEST_OUTPUT_ON_FAILURE: "1"
   ubuntu_latest_autotools:
     runs-on: ubuntu-latest
     steps:
@@ -82,7 +84,9 @@ jobs:
           cd build
           cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON -DICBEXMM=ON -DPYTHON3=ON ..
           make all
-          make CTEST_OUTPUT_ON_FAILURE=1 test
+          make test
+        env:
+          CTEST_OUTPUT_ON_FAILURE: "1"
   ubuntu_latest_autotools_ilp64:
     runs-on: ubuntu-latest
     steps:
@@ -134,8 +138,10 @@ jobs:
           cd build
           cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON -DCOVERALLS=ON ..
           make all
-          make CTEST_OUTPUT_ON_FAILURE=1 test
+          make test
           make coveralls
+        env:
+          CTEST_OUTPUT_ON_FAILURE: "1"
   podman_redhat:
     runs-on: ubuntu-latest
     steps:
@@ -220,7 +226,9 @@ jobs:
           cd build
           LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DBLA_VENDOR=Generic -DEXAMPLES=ON -DICB=ON -DMPI=ON ..
           make all
-          make CTEST_OUTPUT_ON_FAILURE=1 test
+          make test
+        env:
+          CTEST_OUTPUT_ON_FAILURE: "1"
   macos_latest_autotools:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -23,7 +23,7 @@ jobs:
           cd build
           cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON ..
           make all
-          make test
+          CTEST_OUTPUT_ON_FAILURE=1 make test
           make package_source
   ubuntu_latest_autotools:
     runs-on: ubuntu-latest
@@ -77,7 +77,7 @@ jobs:
           sudo apt-get install locate
           sudo updatedb
       - name: Run job
-        run: mkdir build; cd build; cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON -DICBEXMM=ON -DPYTHON3=ON .. && make all test
+        run: mkdir build; cd build; cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON -DICBEXMM=ON -DPYTHON3=ON .. && make all && CTEST_OUTPUT_ON_FAILURE=1 make test
   ubuntu_latest_autotools_ilp64:
     runs-on: ubuntu-latest
     steps:
@@ -129,7 +129,7 @@ jobs:
           cd build
           cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON -DCOVERALLS=ON ..
           make all
-          make test
+          CTEST_OUTPUT_ON_FAILURE=1 make test
           make coveralls
   podman_redhat:
     runs-on: ubuntu-latest
@@ -215,7 +215,7 @@ jobs:
           cd build
           LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DBLA_VENDOR=Generic -DEXAMPLES=ON -DICB=ON -DMPI=ON ..
           make all
-          make test
+          CTEST_OUTPUT_ON_FAILURE=1 make test
   macos_latest_autotools:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -23,7 +23,7 @@ jobs:
           cd build
           cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON ..
           make all
-          CTEST_OUTPUT_ON_FAILURE=1 make test
+          make CTEST_OUTPUT_ON_FAILURE=1 test
           make package_source
   ubuntu_latest_autotools:
     runs-on: ubuntu-latest
@@ -77,7 +77,12 @@ jobs:
           sudo apt-get install locate
           sudo updatedb
       - name: Run job
-        run: mkdir build; cd build; cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON -DICBEXMM=ON -DPYTHON3=ON .. && make all && CTEST_OUTPUT_ON_FAILURE=1 make test
+        run: |
+          mkdir build
+          cd build
+          cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON -DICBEXMM=ON -DPYTHON3=ON ..
+          make all
+          make CTEST_OUTPUT_ON_FAILURE=1 test
   ubuntu_latest_autotools_ilp64:
     runs-on: ubuntu-latest
     steps:
@@ -129,7 +134,7 @@ jobs:
           cd build
           cmake -DEXAMPLES=ON -DMPI=ON -DICB=ON -DCOVERALLS=ON ..
           make all
-          CTEST_OUTPUT_ON_FAILURE=1 make test
+          make CTEST_OUTPUT_ON_FAILURE=1 test
           make coveralls
   podman_redhat:
     runs-on: ubuntu-latest
@@ -215,7 +220,7 @@ jobs:
           cd build
           LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" cmake -DBLA_VENDOR=Generic -DEXAMPLES=ON -DICB=ON -DMPI=ON ..
           make all
-          CTEST_OUTPUT_ON_FAILURE=1 make test
+          make CTEST_OUTPUT_ON_FAILURE=1 test
   macos_latest_autotools:
     runs-on: macos-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,6 +731,9 @@ if(ICB)
   endif()
 endif()
 
+# Testing cmake find_package:
+add_test(NAME find_package COMMAND "${CMAKE_COMMAND}" -P "${PROJECT_SOURCE_DIR}/cmake/TestFindPackage.cmake")
+
 ############################
 # install
 ############################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -732,7 +732,7 @@ if(ICB)
 endif()
 
 # Testing cmake find_package:
-add_test(NAME find_package COMMAND "${CMAKE_COMMAND}" -P "${PROJECT_SOURCE_DIR}/cmake/TestFindPackage.cmake")
+add_test(NAME find_package COMMAND "${CMAKE_COMMAND}" -DARPACK_TST_WITHOUT_TARGET=ON -P "${PROJECT_SOURCE_DIR}/cmake/TestFindPackage.cmake")
 
 ############################
 # install

--- a/arpack-ng-config.cmake.in
+++ b/arpack-ng-config.cmake.in
@@ -11,15 +11,30 @@
 #   add_executable(main main.f)
 #   target_link_libraries(main PARPACK::PARPACK)
 
-# Create local variables.
-set(prefix "@prefix@")
-set(exec_prefix "@exec_prefix@")
-set(libdir "@libdir@")
-set(includedir "@includedir@")
+# Set arpack variables.
+set(ArpackNG_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "ArpackNG: include directories" FORCE)
+if(EXISTS "${CMAKE_INSTALL_PREFIX}/lib/libarpack.a")
+  set(ArpackNG_LIBRARIES "${CMAKE_INSTALL_PREFIX}/lib/libarpack.a" CACHE FILEPATH "ArpackNG: libraries" FORCE)
+elseif(EXISTS "${CMAKE_INSTALL_PREFIX}/lib/libarpack.so")
+  set(ArpackNG_LIBRARIES "${CMAKE_INSTALL_PREFIX}/lib/libarpack.so" CACHE FILEPATH "ArpackNG: libraries" FORCE)
+endif()
 
-# Create arpack targets.
-add_library(ARPACK::ARPACK INTERFACE IMPORTED)
-set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${includedir}/arpack")
-set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_LINK_LIBRARIES      "arpack")
-add_library(PARPACK::PARPACK INTERFACE IMPORTED)
-set_target_properties(PARPACK::PARPACK PROPERTIES INTERFACE_LINK_LIBRARIES    "parpack")
+# Create arpack target.
+add_custom_target(arpack_libs DEPENDS ${ArpackNG_LIBRARIES})
+add_dependencies(ARPACK::ARPACK arpack_libs)
+set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${ArpackNG_INCLUDE_DIRS}")
+set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_LINK_LIBRARIES      "${ArpackNG_LIBRARIES}")
+
+# Set parpack variables.
+set(PArpackNG_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "PArpackNG: include directories" FORCE)
+if(EXISTS "${CMAKE_INSTALL_PREFIX}/lib/libparpack.a")
+  set(PArpackNG_LIBRARIES "${CMAKE_INSTALL_PREFIX}/lib/libparpack.a" CACHE FILEPATH "PArpackNG: libraries" FORCE)
+elseif(EXISTS "${CMAKE_INSTALL_PREFIX}/lib/libparpack.so")
+  set(PArpackNG_LIBRARIES "${CMAKE_INSTALL_PREFIX}/lib/libparpack.so" CACHE FILEPATH "PArpackNG: libraries" FORCE)
+endif()
+
+# Create parpack target.
+add_custom_target(parpack_libs DEPENDS ${PArpackNG_LIBRARIES})
+add_dependencies(PARPACK::PARPACK parpack_libs)
+set_target_properties(PARPACK::PARPACK PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${PArpackNG_INCLUDE_DIRS}")
+set_target_properties(PARPACK::PARPACK PROPERTIES INTERFACE_LINK_LIBRARIES      "${PArpackNG_LIBRARIES}")

--- a/arpack-ng-config.cmake.in
+++ b/arpack-ng-config.cmake.in
@@ -20,10 +20,14 @@ elseif(EXISTS "${CMAKE_INSTALL_PREFIX}/lib/libarpack.so")
 endif()
 
 # Create arpack target.
-add_custom_target(arpack_libs DEPENDS ${ArpackNG_LIBRARIES})
-add_dependencies(ARPACK::ARPACK arpack_libs)
-set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${ArpackNG_INCLUDE_DIRS}")
-set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_LINK_LIBRARIES      "${ArpackNG_LIBRARIES}")
+if(NOT ARPACK_TST_WITHOUT_TARGET) # For testing purposes only.
+    # This can NOT be tested as creating/setting target is not allowed in cmake files.
+    # Arpack users must never set ARPACK_TST_WITHOUT_TARGET, so they can use targets.
+    add_custom_target(arpack_libs DEPENDS ${ArpackNG_LIBRARIES})
+    add_dependencies(ARPACK::ARPACK arpack_libs)
+    set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${ArpackNG_INCLUDE_DIRS}")
+    set_target_properties(ARPACK::ARPACK PROPERTIES INTERFACE_LINK_LIBRARIES      "${ArpackNG_LIBRARIES}")
+endif()
 
 # Set parpack variables.
 set(PArpackNG_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "PArpackNG: include directories" FORCE)
@@ -34,7 +38,11 @@ elseif(EXISTS "${CMAKE_INSTALL_PREFIX}/lib/libparpack.so")
 endif()
 
 # Create parpack target.
-add_custom_target(parpack_libs DEPENDS ${PArpackNG_LIBRARIES})
-add_dependencies(PARPACK::PARPACK parpack_libs)
-set_target_properties(PARPACK::PARPACK PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${PArpackNG_INCLUDE_DIRS}")
-set_target_properties(PARPACK::PARPACK PROPERTIES INTERFACE_LINK_LIBRARIES      "${PArpackNG_LIBRARIES}")
+if(NOT ARPACK_TST_WITHOUT_TARGET) # For testing purposes only.
+    # This can NOT be tested as creating/setting target is not allowed in cmake files.
+    # Arpack users must never set ARPACK_TST_WITHOUT_TARGET, so they can use targets.
+    add_custom_target(parpack_libs DEPENDS ${PArpackNG_LIBRARIES})
+    add_dependencies(PARPACK::PARPACK parpack_libs)
+    set_target_properties(PARPACK::PARPACK PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${PArpackNG_INCLUDE_DIRS}")
+    set_target_properties(PARPACK::PARPACK PROPERTIES INTERFACE_LINK_LIBRARIES      "${PArpackNG_LIBRARIES}")
+endif()

--- a/cmake/TestFindPackage.cmake
+++ b/cmake/TestFindPackage.cmake
@@ -8,14 +8,14 @@ endif ()
 set(CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/local/usr/local/lib/cmake") # Add directory that contains arpack-ng-config.cmake to CMAKE_PREFIX_PATH.
 find_package(arpack-ng CONFIG REQUIRED) # Use CONFIG as we look for arpack-ng-config.cmake (not FindXXX.cmake).
 
-# Build with arpack.
+# Build with arpack: can NOT use arpack targets as they can not be created/set in cmake files.
 add_executable(dnsimp_find_package ${PROJECT_SOURCE_DIR}/EXAMPLES/SIMPLE/dnsimp.f)
-target_include_directories(dnsimp_find_package PUBLIC ARPACK::ARPACK)
-target_link_libraries(dnsimp_find_package ARPACK::ARPACK)
+target_include_directories(dnsimp_find_package PUBLIC "${ArpackNG_INCLUDE_DIRS}")
+target_link_libraries(dnsimp_find_package "${ArpackNG_LIBRARIES}")
 
-# Build with parpack.
+# Build with parpack: can NOT use arpack targets as they can not be created/set in cmake files.
 if (MPI)
     add_executable(pdndrv1_find_package ${PROJECT_SOURCE_DIR}/PARPACK/EXAMPLES/MPI/pdndrv1.f)
-    target_include_directories(pdndrv1_find_package PUBLIC PARPACK::PARPACK)
-    target_link_libraries(pdndrv1_find_package PARPACK::PARPACK)
+    target_include_directories(pdndrv1_find_package PUBLIC "${PArpackNG_INCLUDE_DIRS}")
+    target_link_libraries(pdndrv1_find_package "${PArpackNG_LIBRARIES}")
 endif ()

--- a/cmake/TestFindPackage.cmake
+++ b/cmake/TestFindPackage.cmake
@@ -1,0 +1,21 @@
+# Install arpack-ng in CMAKE_BINARY_DIR.
+execute_process(COMMAND make install DESTDIR=${CMAKE_BINARY_DIR}/local COMMAND_ECHO STDOUT RESULT_VARIABLE CMD_RESULT)
+if (CMD_RESULT)
+    message(FATAL_ERROR "Error in TestFindPackage - install")
+endif ()
+
+# Use find_package: call cmake to use this install of arpack-ng.
+set(CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/local/usr/local/lib/cmake") # Add directory that contains arpack-ng-config.cmake to CMAKE_PREFIX_PATH.
+find_package(arpack-ng CONFIG REQUIRED) # Use CONFIG as we look for arpack-ng-config.cmake (not FindXXX.cmake).
+
+# Build with arpack.
+add_executable(dnsimp_find_package ${PROJECT_SOURCE_DIR}/EXAMPLES/SIMPLE/dnsimp.f)
+target_include_directories(dnsimp_find_package PUBLIC ARPACK::ARPACK)
+target_link_libraries(dnsimp_find_package ARPACK::ARPACK)
+
+# Build with parpack.
+if (MPI)
+    add_executable(pdndrv1_find_package ${PROJECT_SOURCE_DIR}/PARPACK/EXAMPLES/MPI/pdndrv1.f)
+    target_include_directories(pdndrv1_find_package PUBLIC PARPACK::PARPACK)
+    target_link_libraries(pdndrv1_find_package PARPACK::PARPACK)
+endif ()


### PR DESCRIPTION
## Pull request purpose

*.cmake, *.pc files can not be tested as it's a difficult task. Result: *.pc/cmake files are blind-pushed.
Ressorting on old commit that never worked https://github.com/opencollab/arpack-ng/pull/259#issuecomment-603187398 : at the time, if I remeber well cmake refused to `find_package` in a *.cmake file... Not sure if this is allowed now

Any help here would be appreciated (@turboencabulator  ?). Related to #333 too.

Would be good to have this before merging PR impacting cmake/pc files...