### PR TITLE
Replace centos with redhat.

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -131,7 +131,7 @@ jobs:
           make all
           make test
           make coveralls
-  docker_redhat:
+  podman_redhat:
     runs-on: ubuntu-latest
     steps:
       - name: Clone and check out repository code

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -131,7 +131,7 @@ jobs:
           make all
           make test
           make coveralls
-  docker_centos:
+  docker_redhat:
     runs-on: ubuntu-latest
     steps:
       - name: Clone and check out repository code
@@ -145,10 +145,12 @@ jobs:
           git log -1
       - name: Update OS
         run: sudo apt-get update
-      - name: Login to Docker Hub
-        run: sudo docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_TOKEN }}"
+      - name: Install OS
+        # The podman container engine replaced docker as the preferred, maintained, and supported container
+        # runtime of choice for Red Hat Enterprise Linux 8 systems.
+        run: sudo apt-get install podman
       - name: Run job
-        run: ./scripts/travis_centos.sh
+        run: podman run --rm --name=myubi registry.access.redhat.com/ubi8/ubi cat /etc/os-release
   docker_fedora:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Pull request purpose

fixing issue : fix github actions ?

PR seems to take master as a reference (need `pull_request_target` to get docker secrets from master branch of the opencollab reference repo...) : PR seems to still run `docker_centos` (master) even if the PR branch renamed it (`docker_redhat`) ?!...
 
blind-pushing on master: no choice...
