### PR TITLE
Avoid isnan(), which is GNU-specific

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 arpack-ng - 3.9.0
 
+[ Jose E. Roman ]
+* Avoid using isnan() in tests, since is GNU-specific
+
 [ Tom Payerle ]
 * Change the continuation line format for stat.h, debug.h
 

--- a/TESTS/bug_58_double.f
+++ b/TESTS/bug_58_double.f
@@ -417,7 +417,7 @@ c
          print *, ' '
 c
       end if
-      if (isnan(v(1,1))) then
+      if (v(1,1) /= v(1,1)) then   ! result is NaN
          stop 1
       end if
 c


### PR DESCRIPTION
The proposed solution relies on IEEE-754 standard definition of NaN,
https://stackoverflow.com/questions/17389958/is-there-a-standard-way-to-check-for-infinite-and-nan-in-fortran-90-95

This solves a problem that appears with `nvfortran` compiler using CMake build. By the way, why is the CMake build compiling the tests? If I am not wrong the `configure` build skips tests (compiles the libraries only).