### PR TITLE
Standardized suffix for INTERFACE64

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -46,10 +46,10 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          bash ./tstCMakeInstall.sh
-          bash ./tstCMakeInstall.sh 64-
-          bash ./tstCMakeInstall.sh   -ILP64
-          bash ./tstCMakeInstall.sh 64-ILP64
+          bash ./tstCMakeInstall.sh      -OFF
+          bash ./tstCMakeInstall.sh sfx64-OFF
+          bash ./tstCMakeInstall.sh      -ON
+          bash ./tstCMakeInstall.sh sfx64-ON
   ubuntu_latest_autotools:
     runs-on: ubuntu-latest
     steps:
@@ -94,9 +94,9 @@ jobs:
           ./bootstrap
           ./configure
           bash ./tstAutotoolsInstall.sh
-          bash ./tstAutotoolsInstall.sh 64-
-          bash ./tstAutotoolsInstall.sh   -ILP64
-          bash ./tstAutotoolsInstall.sh 64-ILP64
+          bash ./tstAutotoolsInstall.sh sfx64-
+          bash ./tstAutotoolsInstall.sh      -1
+          bash ./tstAutotoolsInstall.sh sfx64-1
   ubuntu_latest_cmake_python:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,7 @@ arpack-ng - 3.9.0
 [ Markus Mützel ]
  * CMake: Handle libraries without "lib" prefix.
  * CMake: Don't override BLAS/LAPACK/MPI flags. Directly use results from the Find* modules instead.
+ * Use automatic default suffix for builds with INTERFACE64.
 
  -- Sylvestre Ledru <sylvestre@debian.org> Mon, 07 Dec 2020 11:37:40 +0100
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,14 +32,18 @@ option(PYTHON3 "Enable python3 support" OFF)
 set(BOOST_PYTHON_LIBSUFFIX "" CACHE STRING "suffix to add to custom boost python libs")
 option(EXAMPLES "Compile ARPACK examples" OFF)
 
-# Suffixes: LIBSUFFIX modify ONLY libraries names, ITF64SUFFIX modify BOTH libraries AND include directory names.
+# LIBSUFFIX modify ONLY library names.
 set(LIBSUFFIX ""
     CACHE STRING "suffix to add to ARPACK libraries names")
-set(ITF64SUFFIX ""
-    CACHE STRING "suffix to add to ARPACK include directory and libraries names (use with INTERFACE64)")
+
 set(SYMBOLSUFFIX ""
     CACHE STRING "suffix to add to ARPACK, BLAS and LAPACK function names")
+
 option(INTERFACE64 "use the 64-bit integer interface (ILP64) for ARPACK, BLAS and LAPACK")
+if (INTERFACE64)
+  # Add suffix to library names, include directory name, and .pc and .cmake file names.
+  set(ITF64SUFFIX "64")
+endif ()
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
@@ -749,16 +753,16 @@ foreach(lib ${LAPACK_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 endforeach()
 string(REPLACE ";" " " PARPACK_PC_LIBS_PRIVATE "${PARPACK_PC_LIBS_PRIVATE}")
 
-configure_file(pkg-config/arpack.pc.in "${PROJECT_BINARY_DIR}/arpack${LIBSUFFIX}${ITF64SUFFIX}.pc" @ONLY)
-configure_file(pkg-config/parpack.pc.in "${PROJECT_BINARY_DIR}/parpack${LIBSUFFIX}${ITF64SUFFIX}.pc" @ONLY)
-configure_file(pkg-config/arpackSolver.pc.in "${PROJECT_BINARY_DIR}/arpackSolver${LIBSUFFIX}${ITF64SUFFIX}.pc" @ONLY)
+configure_file(pkg-config/arpack.pc.in "${PROJECT_BINARY_DIR}/arpack${ITF64SUFFIX}.pc" @ONLY)
+configure_file(pkg-config/parpack.pc.in "${PROJECT_BINARY_DIR}/parpack${ITF64SUFFIX}.pc" @ONLY)
+configure_file(pkg-config/arpackSolver.pc.in "${PROJECT_BINARY_DIR}/arpackSolver${ITF64SUFFIX}.pc" @ONLY)
 
 
 install(TARGETS arpack
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES "${PROJECT_BINARY_DIR}/arpack${LIBSUFFIX}${ITF64SUFFIX}.pc"
+install(FILES "${PROJECT_BINARY_DIR}/arpack${ITF64SUFFIX}.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 if (MPI)
@@ -766,7 +770,7 @@ if (MPI)
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-  install(FILES "${PROJECT_BINARY_DIR}/parpack${LIBSUFFIX}${ITF64SUFFIX}.pc"
+  install(FILES "${PROJECT_BINARY_DIR}/parpack${ITF64SUFFIX}.pc"
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif ()
 
@@ -781,7 +785,7 @@ if(ICB)
   endif()
   if (ICBEXMM)
     install(FILES EXAMPLES/MATRIX_MARKET/arpackSolver.hpp DESTINATION ${ARPACK_INSTALL_INCLUDEDIR})
-    install(FILES "${PROJECT_BINARY_DIR}/arpackSolver${LIBSUFFIX}${ITF64SUFFIX}.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+    install(FILES "${PROJECT_BINARY_DIR}/arpackSolver${ITF64SUFFIX}.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
   endif()
 endif()
 
@@ -806,10 +810,10 @@ configure_file(arpackicb.h.in "${PROJECT_BINARY_DIR}/arpackicb.h" @ONLY)
 install(FILES "${PROJECT_BINARY_DIR}/arpackicb.h" DESTINATION ${ARPACK_INSTALL_INCLUDEDIR})
 
 # Provide find_package for arpack-ng to users.
-configure_file(cmake/arpackng-config.cmake.in "${PROJECT_BINARY_DIR}/arpackng-config.cmake" @ONLY)
-install(FILES "${PROJECT_BINARY_DIR}/arpackng-config.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/arpack-ng) # find_package(arpackng)
-configure_file(cmake/arpackng-config-version.cmake.in "${PROJECT_BINARY_DIR}/arpackng-config-version.cmake" @ONLY)
-install(FILES "${PROJECT_BINARY_DIR}/arpackng-config-version.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/arpack-ng)
+configure_file(cmake/arpackng-config.cmake.in "${PROJECT_BINARY_DIR}/arpackng${ITF64SUFFIX}-config.cmake" @ONLY)
+install(FILES "${PROJECT_BINARY_DIR}/arpackng${ITF64SUFFIX}-config.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/arpackng${ITF64SUFFIX}) # find_package(arpackng) or find_package(arpackng64)
+configure_file(cmake/arpackng-config-version.cmake.in "${PROJECT_BINARY_DIR}/arpackng${ITF64SUFFIX}-config-version.cmake" @ONLY)
+install(FILES "${PROJECT_BINARY_DIR}/arpackng${ITF64SUFFIX}-config-version.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/arpackng${ITF64SUFFIX})
 
 configure_file(cmake/tstCMakeInstall.sh.in ${PROJECT_BINARY_DIR}/tstCMakeInstall.sh @ONLY)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,7 @@ endif
 EXTRA_DIST = README.md PARPACK_CHANGES CHANGES DOCUMENTS VISUAL_STUDIO \
 detect_arpack_bug.m4 CMakeLists.txt
 
-pkgconfig_DATA = arpack@LIBSUFFIX@@ITF64SUFFIX@.pc parpack@LIBSUFFIX@@ITF64SUFFIX@.pc arpackSolver@LIBSUFFIX@@ITF64SUFFIX@.pc
+pkgconfig_DATA = arpack@ITF64SUFFIX@.pc parpack@ITF64SUFFIX@.pc arpackSolver@ITF64SUFFIX@.pc
 
-# Due to the LIBSUFFIX/ITF64SUFFIX, configure doesn't automatically clean this file:
-DISTCLEANFILES = arpack@LIBSUFFIX@@ITF64SUFFIX@.pc parpack@LIBSUFFIX@@ITF64SUFFIX@.pc arpackSolver@LIBSUFFIX@@ITF64SUFFIX@.pc
+# Due to the ITF64SUFFIX, configure doesn't automatically clean these files:
+DISTCLEANFILES = arpack@ITF64SUFFIX@.pc parpack@ITF64SUFFIX@.pc arpackSolver@ITF64SUFFIX@.pc

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ Custom installation examples:
     $ LIBSUFFIX="64" ./configure; make all install
     $ cmake -DLIBSUFFIX="64" ..; make all install
     
-    $ INTERFACE64="1" ITF64SUFFIX="ILP64" ./configure; make all install
-    $ cmake -DINTERFACE64=ON -DITF64SUFFIX="ILP64" ..; make all install
+    $ INTERFACE64="1" ./configure; make all install
+    $ cmake -DINTERFACE64=ON ..; make all install
     
-    $ LIBSUFFIX="64" INTERFACE64="1" ITF64SUFFIX="ILP64" ./configure; make all install
-    $ cmake -DLIBSUFFIX="64" -DINTERFACE64=ON -DITF64SUFFIX="ILP64" ..; make all install
+    $ LIBSUFFIX="64" INTERFACE64="1" ./configure; make all install
+    $ cmake -DLIBSUFFIX="64" -DINTERFACE64=ON ..; make all install
 
  Good luck and enjoy.

--- a/cmake/tstCMakeInstall.sh.in
+++ b/cmake/tstCMakeInstall.sh.in
@@ -16,19 +16,26 @@ mkdir -p "${TMP_DIR}"
 export TMP_PREFIX="${TMP_DIR}/local"
 export LIBSUFFIX="${1%-*}"
 echo "LIBSUFFIX: $LIBSUFFIX"
-export ITF64SUFFIX="${1#*-}"
-echo "ITF64SUFFIX: $ITF64SUFFIX"
-cmake -DCMAKE_INSTALL_PREFIX="${TMP_PREFIX}" -DMPI=ON -DLIBSUFFIX="${LIBSUFFIX}" -DITF64SUFFIX="${ITF64SUFFIX}" .
-make all install
+export INTERFACE64="${1#*-}"
+echo "INTERFACE64: $INTERFACE64"
+cmake -DCMAKE_INSTALL_PREFIX="${TMP_PREFIX}" -DMPI=ON -DLIBSUFFIX="${LIBSUFFIX}" -DINTERFACE64="${INTERFACE64}" .
+cmake --build .
+cmake --install .
 tree "${TMP_PREFIX}"
+
+if [ x$INTERFACE64 = xON ]; then
+  export ITF64SUFFIX="64"
+else
+  export ITF64SUFFIX=
+fi
 
 # 3. Setup environment for find_package to work (what you typically in module-environment files).
 
 cd "${TMP_DIR}"
-export PKG_CONFIG_PATH="$(find ${TMP_PREFIX} -name arpack${LIBSUFFIX}${ITF64SUFFIX}.pc)"
+export PKG_CONFIG_PATH="$(find ${TMP_PREFIX} -name arpack${ITF64SUFFIX}.pc)"
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH%/*}" # Same as dirname.
 echo "PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
-export arpackng_DIR="$(find ${TMP_PREFIX} -name arpackng-config.cmake)"
+export arpackng_DIR="$(find ${TMP_PREFIX} -name arpackng${ITF64SUFFIX}-config.cmake)"
 export arpackng_DIR="${arpackng_DIR%/*}" # Same as dirname.
 echo "arpackng_DIR: $arpackng_DIR"
 
@@ -50,7 +57,7 @@ echo ""                                                                 >> CMake
 echo "find_package(BLAS REQUIRED)"                                      >> CMakeLists.txt
 echo "find_package(LAPACK REQUIRED)"                                    >> CMakeLists.txt
 echo "find_package(MPI REQUIRED COMPONENTS Fortran)"                    >> CMakeLists.txt
-echo "find_package(arpackng REQUIRED)"                                  >> CMakeLists.txt
+echo "find_package(arpackng${ITF64SUFFIX} REQUIRED)"                    >> CMakeLists.txt
 echo ""                                                                 >> CMakeLists.txt
 echo "add_executable(dnbdr1 dnband.f dnbdr1.f)"                         >> CMakeLists.txt
 echo "target_include_directories(dnbdr1 INTERFACE BLAS::BLAS)"          >> CMakeLists.txt
@@ -73,8 +80,8 @@ echo "target_include_directories(pdndrv1 INTERFACE PARPACK::PARPACK)"   >> CMake
 echo "target_link_libraries(pdndrv1 PARPACK::PARPACK)"                  >> CMakeLists.txt
 echo ""                                                                 >> CMakeLists.txt
 echo "find_package(PkgConfig REQUIRED)"                                 >> CMakeLists.txt
-echo "pkg_check_modules(ARPACK IMPORTED_TARGET REQUIRED arpack${LIBSUFFIX}${ITF64SUFFIX})"   >> CMakeLists.txt
-echo "pkg_check_modules(PARPACK IMPORTED_TARGET REQUIRED parpack${LIBSUFFIX}${ITF64SUFFIX})" >> CMakeLists.txt
+echo "pkg_check_modules(ARPACK IMPORTED_TARGET REQUIRED arpack${ITF64SUFFIX})"   >> CMakeLists.txt
+echo "pkg_check_modules(PARPACK IMPORTED_TARGET REQUIRED parpack${ITF64SUFFIX})" >> CMakeLists.txt
 echo ""                                                                 >> CMakeLists.txt
 echo "add_executable(dnbdr3 dnband.f dnbdr3.f)"                         >> CMakeLists.txt
 echo "target_include_directories(dnbdr3 INTERFACE BLAS::BLAS)"          >> CMakeLists.txt
@@ -101,10 +108,13 @@ echo "target_link_libraries(pdndrv3 PkgConfig::PARPACK)"                >> CMake
 mkdir -p build
 cd build
 
-cmake ..
-make all VERBOSE=1
+cmake -DCMAKE_PREFIX_PATH=$arpackng_DIR/.. ..
+cmake --build . -v
 
-./dnbdr1
-mpirun -n 2 ./pdndrv1
-./dnbdr3
-mpirun -n 2 ./pdndrv3
+# There is no pre-built BLAS/LAPACK with 64-bit Fortran integers on Ubuntu
+if [ x$INTERFACE64 != xON ]; then
+  ./dnbdr1
+  mpirun -n 2 ./pdndrv1
+  ./dnbdr3
+  mpirun -n 2 ./pdndrv3
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,7 @@ dnl Check for LAPACK libraries
 AX_LAPACK([], [AC_MSG_ERROR([cannot find LAPACK libraries])])
 
 AC_ARG_VAR(INTERFACE64, [set to 1 to use the 64-bit integer interface (ILP64) for ARPACK, BLAS and LAPACK])
+dnl ITF64SUFFIX is suffix to add to ARPACK include directory and library names
 if test x"$INTERFACE64" == x"1"; then
   AC_LANG_PUSH([Fortran 77])
   AX_CHECK_COMPILE_FLAG(-fdefault-integer-8, FFLAGS="$FFLAGS -fdefault-integer-8",
@@ -32,13 +33,14 @@ if test x"$INTERFACE64" == x"1"; then
                         AX_CHECK_COMPILE_FLAG(-i8, FCFLAGS="$FCFLAGS -i8",
                                               AC_MSG_WARN([configure does not know how to make your Fortran compiler use 64-bit integers: set it manually via FCFLAGS.])))
   AC_LANG_POP([Fortran])
+  ITF64SUFFIX="64"
 else
   INTERFACE64=0
+  ITF64SUFFIX=""
 fi
 
-dnl Suffixes: LIBSUFFIX modify ONLY libraries names, ITF64SUFFIX modify BOTH libraries AND include directory names.
+dnl LIBSUFFIX modify ONLY library names
 AC_ARG_VAR(LIBSUFFIX, [suffix to add to ARPACK libraries names])
-AC_ARG_VAR(ITF64SUFFIX, [suffix to add to ARPACK include directory and libraries names (use with INTERFACE64)])
 AC_ARG_VAR(SYMBOLSUFFIX, [suffix to add to ARPACK, BLAS and LAPACK function names])
 
 ifdef([LT_INIT], [], [
@@ -298,10 +300,12 @@ AC_SUBST([ARPACK_PC_LIBS_PRIVATE], ["$LAPACK_LIBS $BLAS_LIBS"])
 AC_SUBST([PARPACK_PC_LIBS_PRIVATE], ["$LAPACK_LIBS $BLAS_LIBS $MPI_Fortran_LIBS"])
 
 AC_CONFIG_FILES([
-	arpack$LIBSUFFIX$ITF64SUFFIX.pc:pkg-config/arpack.pc.in
-	parpack$LIBSUFFIX$ITF64SUFFIX.pc:pkg-config/parpack.pc.in
-	arpackSolver$LIBSUFFIX$ITF64SUFFIX.pc:pkg-config/arpackSolver.pc.in
+	arpack$ITF64SUFFIX.pc:pkg-config/arpack.pc.in
+	parpack$ITF64SUFFIX.pc:pkg-config/parpack.pc.in
+	arpackSolver$ITF64SUFFIX.pc:pkg-config/arpackSolver.pc.in
 ], [], [LIBSUFFIX="$LIBSUFFIX"; ITF64SUFFIX="$ITF64SUFFIX"])
+
+AC_SUBST([ITF64SUFFIX], ["$ITF64SUFFIX"])
 
 dnl We do NOT want arpackng*.cmake files to be created: @MPI@ can not be replaced.
 AC_CONFIG_FILES([

--- a/pkg-config/parpack.pc.in
+++ b/pkg-config/parpack.pc.in
@@ -7,7 +7,7 @@ Name: @PACKAGE_NAME@
 Description: Collection of Fortran77 subroutines designed to solve large scale eigenvalue problems
 Version: @PACKAGE_VERSION@
 URL: @PACKAGE_URL@
-Requires.private: arpack@LIBSUFFIX@@ITF64SUFFIX@
+Requires.private: arpack@ITF64SUFFIX@
 Libs: -L${libdir} -lparpack@LIBSUFFIX@@ITF64SUFFIX@
 Libs.private: @PARPACK_PC_LIBS_PRIVATE@
 Cflags: -I${includedir}

--- a/pkg-config/tstAutotoolsInstall.sh.in
+++ b/pkg-config/tstAutotoolsInstall.sh.in
@@ -20,16 +20,22 @@ export PROJECT_SOURCE_DIR="$(pwd)"
 export TMP_PREFIX="${TMP_DIR}/local"
 export LIBSUFFIX="${1%-*}"
 echo "LIBSUFFIX: $LIBSUFFIX"
-export ITF64SUFFIX="${1#*-}"
-echo "ITF64SUFFIX: $ITF64SUFFIX"
-LIBSUFFIX="${LIBSUFFIX}" ITF64SUFFIX="${ITF64SUFFIX}" ./configure --prefix="${TMP_PREFIX}" --enable-mpi
+export INTERFACE64="${1#*-}"
+echo "INTERFACE64: $INTERFACE64"
+LIBSUFFIX="${LIBSUFFIX}" INTERFACE64="${INTERFACE64}" ./configure --prefix="${TMP_PREFIX}" --enable-mpi
 make all install
 tree "${TMP_PREFIX}"
+
+if [ x$INTERFACE64 = xON ]; then
+  export ITF64SUFFIX="64"
+else
+  export ITF64SUFFIX=
+fi
 
 # 3. Setup environment for PKG_CHECK_MODULES to work (what you typically in module-environment files).
 
 cd "${TMP_DIR}"
-export PKG_CONFIG_PATH="$(find ${TMP_PREFIX} -name arpack${LIBSUFFIX}${ITF64SUFFIX}.pc)"
+export PKG_CONFIG_PATH="$(find ${TMP_PREFIX} -name arpack${ITF64SUFFIX}.pc)"
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH%/*}" # Same as dirname.
 echo "PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
 
@@ -64,11 +70,11 @@ echo "AX_MPI([], AC_MSG_ERROR([could not compile a Fortran MPI test program]))" 
 echo "F77=\$MPIF77                                                            " >> configure.ac
 echo "AC_SUBST([MPI_Fortran_LIBS])                                            " >> configure.ac
 echo "                                                                        " >> configure.ac
-echo "PKG_CHECK_MODULES([ARPACK], [arpack${LIBSUFFIX}${ITF64SUFFIX}])         " >> configure.ac
+echo "PKG_CHECK_MODULES([ARPACK], [arpack${ITF64SUFFIX}])                     " >> configure.ac
 echo "AC_SUBST([ARPACK_CFLAGS])                                               " >> configure.ac
 echo "AC_SUBST([ARPACK_LIBS])                                                 " >> configure.ac
 echo "                                                                        " >> configure.ac
-echo "PKG_CHECK_MODULES([PARPACK], [parpack${LIBSUFFIX}${ITF64SUFFIX}])       " >> configure.ac
+echo "PKG_CHECK_MODULES([PARPACK], [parpack${ITF64SUFFIX}])                   " >> configure.ac
 echo "AC_SUBST([PARPACK_CFLAGS])                                              " >> configure.ac
 echo "AC_SUBST([PARPACK_LIBS])                                                " >> configure.ac
 echo "                                                                        " >> configure.ac
@@ -99,5 +105,8 @@ autoreconf --force --verbose --install
 ./configure
 make all
 
-./dnbdr1
-mpirun -n 2 ./pdndrv1
+# There is no pre-built BLAS/LAPACK with 64-bit Fortran integers on Ubuntu
+if [ x$INTERFACE64 != x1 ]; then
+  ./dnbdr1
+  mpirun -n 2 ./pdndrv1
+fi


### PR DESCRIPTION
This is a proposal for how the suffix could be standardized that is used to indicate that the package was built for 64-bit Fortran integers.

See also #358.