### PR TITLE
Simplify build rules for CI on Windows

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -221,30 +221,31 @@ jobs:
           make check
   windows_latest_cmake:
     runs-on: windows-latest
+    defaults:
+      run:
+        # Use MSYS2 as default shell
+        shell: msys2 {0}
     steps:
-      - name: Clone and check out repository code
-        uses: actions/checkout@v2
+      - name: Install MSYS2 build environment
+        uses: msys2/setup-msys2@v2
         with:
-          fetch-depth: 0
-          ref: ${{github.event.pull_request.head.ref}} # Branch where changes are implemented.
-          repository: ${{github.event.pull_request.head.repo.full_name}} # Repo where changes are implemented.
+          update: true
+          msystem: MINGW64
+          install: >-
+            base-devel
+            git
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-gcc-fortran
+            mingw-w64-x86_64-openblas
+      - name: Clone and check out repository code
+        uses: actions/checkout@v3
       - name: Check commit
         run: |
           git log -1
-      - name: Update OS
-        run: |
-          choco install -y msys2
-          choco upgrade --no-progress -y msys2
-          C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start -msys2 -mingw64 -full-path -here -c \$\* -- pacman --sync --noconfirm mingw-w64-x86_64-toolchain
-          C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start -msys2 -mingw64 -full-path -here -c \$\* -- pacman --sync --noconfirm mingw-w64-x86_64-cmake
-          C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start -msys2 -mingw64 -full-path -here -c \$\* -- pacman --sync --noconfirm mingw-w64-x86_64-toolchain
-          C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start -msys2 -mingw64 -full-path -here -c \$\* -- pacman --sync --noconfirm mingw-w64-x86_64-make
-          C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start -msys2 -mingw64 -full-path -here -c \$\* -- pacman --sync --noconfirm mingw-w64-x86_64-ninja
-          C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start -msys2 -mingw64 -full-path -here -c \$\* -- pacman --sync --noconfirm mingw-w64-x86_64-openblas
       - name: Run job
         run: |
-          echo "C:\\tools\\msys64\\mingw64\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          mkdir build
-          C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start -msys2 -mingw64 -full-path -where build -c \$\* -- cmake -G 'Ninja' -DICB=ON .. # -DEXAMPLES=ON KO
-          C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start -msys2 -mingw64 -full-path -where build -c \$\* -- ninja all
-          C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start -msys2 -mingw64 -full-path -where build -c \$\* -- ninja test
+          mkdir -p build && cd build
+          cmake -GNinja -DICB=ON .. # -DEXAMPLES=ON KO
+          cmake --build . -v
+          ctest

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -239,7 +239,11 @@ jobs:
             mingw-w64-x86_64-gcc-fortran
             mingw-w64-x86_64-openblas
       - name: Clone and check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}} # Branch where changes are implemented.
+          repository: ${{github.event.pull_request.head.repo.full_name}} # Repo where changes are implemented.
       - name: Check commit
         run: |
           git log -1


### PR DESCRIPTION
Use action msys2/setup-msys2 to install the MSYS2 build environment.
Among other things, this caches the downloaded packages which might speed up the installation process. But the main advantage is imho that it simplifies the commands that are used for building, and makes them easier to read.