### PR TITLE
Fix typos in SRC/

### DIFF
--- a/SRC/dnapps.f
+++ b/SRC/dnapps.f
@@ -13,7 +13,7 @@ c
 c     A*(V_{k}*Q) - (V_{k}*Q)*(Q^T* H_{k}*Q) = r_{k+p}*e_{k+p}^T * Q
 c
 c  where Q is an orthogonal matrix which is the product of rotations
-c  and reflections resulting from the NP bulge chage sweeps.
+c  and reflections resulting from the NP bulge change sweeps.
 c  The updated Arnoldi factorization becomes:
 c
 c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.

--- a/SRC/dnaup2.f
+++ b/SRC/dnaup2.f
@@ -598,7 +598,7 @@ c
 c
 c           %----------------------------------------------------%
 c           | Sort the Ritz values according to the scaled Ritz  |
-c           | esitmates.  This will push all the converged ones  |
+c           | estimates.  This will push all the converged ones  |
 c           | towards the front of ritzr, ritzi, bounds          |
 c           | (in the case when NCONV < NEV.)                    |
 c           %----------------------------------------------------%

--- a/SRC/dnaupd.f
+++ b/SRC/dnaupd.f
@@ -298,7 +298,7 @@ c     eigenvector z of the original problem is recovered by solving
 c     L`z = x  where x is a Ritz vector of OP.
 c
 c  4. At present there is no a-priori analysis to guide the selection
-c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV + 2.
+c     of NCV relative to NEV.  The only formal requirement is that NCV > NEV + 2.
 c     However, it is recommended that NCV .ge. 2*NEV+1.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
 c     NCV while keeping NEV fixed for a given test problem.  This will

--- a/SRC/dneupd.f
+++ b/SRC/dneupd.f
@@ -994,9 +994,9 @@ c
 c
       if (type .eq. 'SHIFTI' .and. msglvl .gt. 1) then
          call dvout (logfil, nconv, dr, ndigit,
-     &   '_neupd: Untransformed real part of the Ritz valuess.')
+     &   '_neupd: Untransformed real part of the Ritz values.')
          call dvout  (logfil, nconv, di, ndigit,
-     &   '_neupd: Untransformed imag part of the Ritz valuess.')
+     &   '_neupd: Untransformed imag part of the Ritz values.')
          call dvout (logfil, nconv, workl(ihbds), ndigit,
      &   '_neupd: Ritz estimates of untransformed Ritz values.')
       else if (type .eq. 'REGULR' .and. msglvl .gt. 1) then

--- a/SRC/dsaup2.f
+++ b/SRC/dsaup2.f
@@ -588,7 +588,7 @@ c
 c
 c           %----------------------------------------------------%
 c           | Sort the Ritz values according to the scaled Ritz  |
-c           | esitmates.  This will push all the converged ones  |
+c           | estimates.  This will push all the converged ones  |
 c           | towards the front of ritzr, ritzi, bounds          |
 c           | (in the case when NCONV < NEV.)                    |
 c           %----------------------------------------------------%

--- a/SRC/dsaupd.f
+++ b/SRC/dsaupd.f
@@ -297,7 +297,7 @@ c     eigenvector z of the original problem is recovered by solving
 c     L`z = x  where x is a Ritz vector of OP.
 c
 c  4. At present there is no a-priori analysis to guide the selection
-c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV.
+c     of NCV relative to NEV.  The only formal requirement is that NCV > NEV.
 c     However, it is recommended that NCV .ge. 2*NEV.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
 c     NCV while keeping NEV fixed for a given test problem.  This will

--- a/SRC/dstqrb.f
+++ b/SRC/dstqrb.f
@@ -93,7 +93,7 @@ c
 c\Remarks
 c     1. Starting with version 2.5, this routine is a modified version
 c        of LAPACK version 2.0 subroutine SSTEQR. No lines are deleted,
-c        only commeted out and new lines inserted.
+c        only commented out and new lines inserted.
 c        All lines commented out have "c$$$" at the beginning.
 c        Note that the LAPACK version 1.0 subroutine SSTEQR contained
 c        bugs.

--- a/SRC/snapps.f
+++ b/SRC/snapps.f
@@ -13,7 +13,7 @@ c
 c     A*(V_{k}*Q) - (V_{k}*Q)*(Q^T* H_{k}*Q) = r_{k+p}*e_{k+p}^T * Q
 c
 c  where Q is an orthogonal matrix which is the product of rotations
-c  and reflections resulting from the NP bulge chage sweeps.
+c  and reflections resulting from the NP bulge change sweeps.
 c  The updated Arnoldi factorization becomes:
 c
 c     A*VNEW_{k} - VNEW_{k}*HNEW_{k} = rnew_{k}*e_{k}^T.

--- a/SRC/snaup2.f
+++ b/SRC/snaup2.f
@@ -598,7 +598,7 @@ c
 c
 c           %----------------------------------------------------%
 c           | Sort the Ritz values according to the scaled Ritz  |
-c           | esitmates.  This will push all the converged ones  |
+c           | estimates.  This will push all the converged ones  |
 c           | towards the front of ritzr, ritzi, bounds          |
 c           | (in the case when NCONV < NEV.)                    |
 c           %----------------------------------------------------%

--- a/SRC/snaupd.f
+++ b/SRC/snaupd.f
@@ -298,7 +298,7 @@ c     eigenvector z of the original problem is recovered by solving
 c     L`z = x  where x is a Ritz vector of OP.
 c
 c  4. At present there is no a-priori analysis to guide the selection
-c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV + 2.
+c     of NCV relative to NEV.  The only formal requirement is that NCV > NEV + 2.
 c     However, it is recommended that NCV .ge. 2*NEV+1.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
 c     NCV while keeping NEV fixed for a given test problem.  This will

--- a/SRC/sneupd.f
+++ b/SRC/sneupd.f
@@ -993,9 +993,9 @@ c
 c
       if (type .eq. 'SHIFTI' .and. msglvl .gt. 1) then
          call svout(logfil, nconv, dr, ndigit,
-     &   '_neupd: Untransformed real part of the Ritz valuess.')
+     &   '_neupd: Untransformed real part of the Ritz values.')
          call svout (logfil, nconv, di, ndigit,
-     &   '_neupd: Untransformed imag part of the Ritz valuess.')
+     &   '_neupd: Untransformed imag part of the Ritz values.')
          call svout(logfil, nconv, workl(ihbds), ndigit,
      &   '_neupd: Ritz estimates of untransformed Ritz values.')
       else if (type .eq. 'REGULR' .and. msglvl .gt. 1) then

--- a/SRC/ssaup2.f
+++ b/SRC/ssaup2.f
@@ -587,7 +587,7 @@ c
 c
 c           %----------------------------------------------------%
 c           | Sort the Ritz values according to the scaled Ritz  |
-c           | esitmates.  This will push all the converged ones  |
+c           | estimates.  This will push all the converged ones  |
 c           | towards the front of ritzr, ritzi, bounds          |
 c           | (in the case when NCONV < NEV.)                    |
 c           %----------------------------------------------------%

--- a/SRC/ssaupd.f
+++ b/SRC/ssaupd.f
@@ -297,7 +297,7 @@ c     eigenvector z of the original problem is recovered by solving
 c     L`z = x  where x is a Ritz vector of OP.
 c
 c  4. At present there is no a-priori analysis to guide the selection
-c     of NCV relative to NEV.  The only formal requrement is that NCV > NEV.
+c     of NCV relative to NEV.  The only formal requirement is that NCV > NEV.
 c     However, it is recommended that NCV .ge. 2*NEV.  If many problems of
 c     the same type are to be solved, one should experiment with increasing
 c     NCV while keeping NEV fixed for a given test problem.  This will

--- a/SRC/sstqrb.f
+++ b/SRC/sstqrb.f
@@ -93,7 +93,7 @@ c
 c\Remarks
 c     1. Starting with version 2.5, this routine is a modified version
 c        of LAPACK version 2.0 subroutine SSTEQR. No lines are deleted,
-c        only commeted out and new lines inserted.
+c        only commented out and new lines inserted.
 c        All lines commented out have "c$$$" at the beginning.
 c        Note that the LAPACK version 1.0 subroutine SSTEQR contained
 c        bugs.


### PR DESCRIPTION
Found via `codespell -q 3 -L canot,coo,inout,reord,workd`