### PR TITLE
bug fix: modify the condition for ierr=-3 in pxneupd.f

### DIFF
--- a/PARPACK/SRC/MPI/pcneupd.f
+++ b/PARPACK/SRC/MPI/pcneupd.f
@@ -316,7 +316,7 @@ c
      &           invsub, iuptri, iwev  , j    , ldh   , ldq   ,
      &           mode  , msglvl, ritz  , wr   , k     , irz   ,
      &           ibd   , outncv, iq    , np   , numcnv, jj    ,
-     &           ishift
+     &           ishift, nglo
       Complex
      &           rnorm, temp, vl(1)
       Real
@@ -377,13 +377,16 @@ c     %-------------------------------%
 c
       ierr = 0
 c
+      nglo = n
+      call MPI_ALLREDUCE(MPI_IN_PLACE, [nglo], 1,
+     &   MPI_INTEGER, MPI_SUM, comm, ierr )
       if (nconv .le. 0) then
          ierr = -14
       else if (n .le. 0) then
          ierr = -1
       else if (nev .le. 0) then
          ierr = -2
-      else if (ncv .le. nev+1 .or.  ncv .gt. n) then
+      else if (ncv .le. nev+1 .or.  ncv .gt. nglo) then
          ierr = -3
       else if (which .ne. 'LM' .and.
      &        which .ne. 'SM' .and.

--- a/PARPACK/SRC/MPI/pdneupd.f
+++ b/PARPACK/SRC/MPI/pdneupd.f
@@ -368,7 +368,7 @@ c
      &           mode  , msglvl, outncv, ritzr   ,
      &           ritzi , wri   , wrr   , irr     ,
      &           iri   , ibd   , ishift, numcnv  ,
-     &           np    , jj
+     &           np    , jj,  nglo
       logical    reord
       Double precision
      &           conds  , rnorm, sep  , temp,
@@ -423,13 +423,16 @@ c     %--------------%
 c
       ierr = 0
 c
+      nglo = n
+      call MPI_ALLREDUCE(MPI_IN_PLACE, [nglo], 1,
+     &   MPI_INTEGER, MPI_SUM, comm, ierr )
       if (nconv .le. 0) then
          ierr = -14
       else if (n .le. 0) then
          ierr = -1
       else if (nev .le. 0) then
          ierr = -2
-      else if (ncv .le. nev+1) then
+      else if (ncv .le. nev+1 .or.  ncv .gt. nglo) then
          ierr = -3
       else if (which .ne. 'LM' .and.
      &        which .ne. 'SM' .and.

--- a/PARPACK/SRC/MPI/psneupd.f
+++ b/PARPACK/SRC/MPI/psneupd.f
@@ -368,7 +368,7 @@ c
      &           mode  , msglvl, outncv, ritzr   ,
      &           ritzi , wri   , wrr   , irr     ,
      &           iri   , ibd   , ishift, numcnv  ,
-     &           np    , jj
+     &           np    , jj,  nglo
       logical    reord
       Real
      &           conds  , rnorm, sep  , temp,
@@ -423,13 +423,16 @@ c     %--------------%
 c
       ierr = 0
 c
+      nglo = n
+      call MPI_ALLREDUCE(MPI_IN_PLACE, [nglo], 1,
+     &   MPI_INTEGER, MPI_SUM, comm, ierr )
       if (nconv .le. 0) then
          ierr = -14
       else if (n .le. 0) then
          ierr = -1
       else if (nev .le. 0) then
          ierr = -2
-      else if (ncv .le. nev+1) then
+      else if (ncv .le. nev+1 .or.  ncv .gt. nglo) then
          ierr = -3
       else if (which .ne. 'LM' .and.
      &        which .ne. 'SM' .and.

--- a/PARPACK/SRC/MPI/pzneupd.f
+++ b/PARPACK/SRC/MPI/pzneupd.f
@@ -316,7 +316,7 @@ c
      &           invsub, iuptri, iwev  , j    , ldh   , ldq   ,
      &           mode  , msglvl, ritz  , wr   , k     , irz   ,
      &           ibd   , outncv, iq    , np   , numcnv, jj    ,
-     &           ishift
+     &           ishift, nglo
       Complex*16
      &           rnorm, temp, vl(1)
       Double precision
@@ -377,13 +377,16 @@ c     %-------------------------------%
 c
       ierr = 0
 c
+      nglo = n
+      call MPI_ALLREDUCE(MPI_IN_PLACE, [nglo], 1,
+     &   MPI_INTEGER, MPI_SUM, comm, ierr )
       if (nconv .le. 0) then
          ierr = -14
       else if (n .le. 0) then
          ierr = -1
       else if (nev .le. 0) then
          ierr = -2
-      else if (ncv .le. nev+1 .or.  ncv .gt. n) then
+      else if (ncv .le. nev+1 .or.  ncv .gt. nglo) then
          ierr = -3
       else if (which .ne. 'LM' .and.
      &        which .ne. 'SM' .and.


### PR DESCRIPTION
Change "else if (ncv .le. nev+1 .or.  ncv .gt. n) then" to "else if (ncv .le. nev+1 .or.  ncv .gt. nglo) then" in pxneupd.f before returning ierr=-3. nglo is the global number of matrix size, instead of local number of matrix size. 


