### PR TITLE
Link to LAPACK before BLAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,10 +386,10 @@ add_library(arpack ${arpackutil_STAT_SRCS} ${arpacksrc_STAT_SRCS} ${arpacksrc_IC
 
 target_link_libraries(arpack
   PUBLIC
-  $<INSTALL_INTERFACE:$<IF:$<BOOL:${BUILD_SHARED_LIBS}>,,BLAS::BLAS>>
   $<INSTALL_INTERFACE:$<IF:$<BOOL:${BUILD_SHARED_LIBS}>,,LAPACK::LAPACK>>
-  $<BUILD_INTERFACE:BLAS::BLAS>
+  $<INSTALL_INTERFACE:$<IF:$<BOOL:${BUILD_SHARED_LIBS}>,,BLAS::BLAS>>
   $<BUILD_INTERFACE:LAPACK::LAPACK>
+  $<BUILD_INTERFACE:BLAS::BLAS>
 )
 target_link_options(arpack PUBLIC "${EXTRA_LDFLAGS}")
 set_target_properties(arpack PROPERTIES OUTPUT_NAME arpack${LIBSUFFIX}${ITF64SUFFIX})


### PR DESCRIPTION
This PR swaps the order of linking to have LAPACK before BLAS.

Why ? When experimenting packaging the repo through vcpkg, I faced a peculiar problem when using static libraries (through WSL on Ubuntu 20.04 with GCC 9.4).

The first generated build command failed (with undefined references)

```bash
[1/2] /usr/bin/c++  -isystem /home/fabien/vcpkg/installed/x64-linux/include/arpack-ng -O2 -g -DNDEBUG -std=gnu++17 -MD -MT CMakeFiles/main.dir/main.cpp.o -MF CMakeFiles/main.dir/main.cpp.o.d -o CMakeFiles/main.dir/main.cpp.o -c ../../../main.cpp
[2/2] : && /usr/bin/c++ -O2 -g -DNDEBUG  CMakeFiles/main.dir/main.cpp.o -o main  /home/fabien/vcpkg/installed/x64-linux/lib/libarpack.a  /home/fabien/vcpkg/installed/x64-linux/lib/libopenblas.a  /home/fabien/vcpkg/installed/x64-linux/lib/liblapack.a  -lm  /usr/lib/x86_64-linux-gnu/libgfortran.so.5  -lgfortran  -lquadmath && :
FAILED: main 
```

By some chance it worked when fiddling around by manually adding targets in the CMakeLists of the test case

```bash
[1/2] /usr/bin/c++  -isystem /home/fabien/vcpkg/installed/x64-linux/include/arpack-ng -O2 -g -DNDEBUG -std=gnu++17 -MD -MT CMakeFiles/main.dir/main.cpp.o -MF CMakeFiles/main.dir/main.cpp.o.d -o CMakeFiles/main.dir/main.cpp.o -c ../../../main.cpp
[2/2] : && /usr/bin/c++ -O2 -g -DNDEBUG  CMakeFiles/main.dir/main.cpp.o -o main  /home/fabien/vcpkg/installed/x64-linux/lib/libarpack.a  /home/fabien/vcpkg/installed/x64-linux/lib/liblapack.a  -lm  /usr/lib/x86_64-linux-gnu/libgfortran.so.5  /home/fabien/vcpkg/installed/x64-linux/lib/libopenblas.a  -lgfortran  -lquadmath && :
```

The main difference was that `liblapack.a` was put before `libopenblas.a`. I tried the change given in this PR and it built successfully. 

It might not be the optimal solution, but the correct CMake alternative seems to be relatively recent (v3.24), see https://gitlab.kitware.com/cmake/cmake/-/issues/20078 and https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:LINK_LIBRARY