### PR TITLE
Fix library consumption from C++17 on Windows

### DIFF
--- a/arpackdef.h.in
+++ b/arpackdef.h.in
@@ -14,7 +14,9 @@
 #define a_uint unsigned int
 #endif
 #ifdef _MSC_VER
+#define _CRT_USE_C_COMPLEX_H
 #include <complex.h>
+#undef _CRT_USE_C_COMPLEX_H
 #define a_fcomplex _Fcomplex
 #define a_dcomplex _Dcomplex
 #ifndef CMPLXF


### PR DESCRIPTION
Trying to use ARPACK on Windows from C++ with standard &geq; 17 fails because C `<complex.h>` content is replaced by C++ `<complex>` automatically unless the escape hatch macro is used `_CRT_USE_C_COMPLEX_H `

See https://github.com/MicrosoftDocs/cpp-docs/issues/4374 and https://github.com/microsoft/STL/issues/3280 for details.