### PR TITLE
Run all examples for job `windows_latest_cmake` in CI

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -269,6 +269,9 @@ jobs:
             mingw-w64-x86_64-ninja
             mingw-w64-x86_64-gcc-fortran
             mingw-w64-x86_64-openblas
+            mingw-w64-x86_64-msmpi
+      - name: Install MS-MPI (for mpiexec)
+        uses: mpi4py/setup-mpi@v1
       - name: Clone and check out repository code
         uses: actions/checkout@v2
         with:
@@ -283,4 +286,8 @@ jobs:
           mkdir -p build && cd build
           cmake -GNinja -DICB=ON -DEXAMPLES=ON -DMPI=ON ..
           cmake --build . -v
+      - name: Run tests
+        run: |
+          export PATH="/c/Program Files/Microsoft MPI/Bin":$PATH # add mpiexec to msys2 path
+          cd build
           ctest --output-on-failure

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -281,6 +281,6 @@ jobs:
       - name: Run job
         run: |
           mkdir -p build && cd build
-          cmake -GNinja -DICB=ON -DEXAMPLES=ON ..
+          cmake -GNinja -DICB=ON -DEXAMPLES=ON -DMPI=ON ..
           cmake --build . -v
           ctest --output-on-failure

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -281,6 +281,6 @@ jobs:
       - name: Run job
         run: |
           mkdir -p build && cd build
-          cmake -GNinja -DICB=ON .. # -DEXAMPLES=ON KO
+          cmake -GNinja -DICB=ON -DEXAMPLES=ON ..
           cmake --build . -v
           ctest --output-on-failure

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -269,7 +269,6 @@ jobs:
             mingw-w64-x86_64-ninja
             mingw-w64-x86_64-gcc-fortran
             mingw-w64-x86_64-openblas
-            mingw-w64-x86_64-msmpi
       - name: Clone and check out repository code
         uses: actions/checkout@v2
         with:
@@ -282,6 +281,6 @@ jobs:
       - name: Run job
         run: |
           mkdir -p build && cd build
-          cmake -GNinja -DICB=ON -DMPI=ON -DEXAMPLES=ON ..
+          cmake -GNinja -DICB=ON -DEXAMPLES=ON ..
           cmake --build . -v
           ctest --output-on-failure

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -269,6 +269,7 @@ jobs:
             mingw-w64-x86_64-ninja
             mingw-w64-x86_64-gcc-fortran
             mingw-w64-x86_64-openblas
+            mingw-w64-x86_64-msmpi
       - name: Clone and check out repository code
         uses: actions/checkout@v2
         with:
@@ -281,6 +282,6 @@ jobs:
       - name: Run job
         run: |
           mkdir -p build && cd build
-          cmake -GNinja -DICB=ON -DEXAMPLES=ON ..
+          cmake -GNinja -DICB=ON -DMPI=ON -DEXAMPLES=ON ..
           cmake --build . -v
           ctest --output-on-failure

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 arpack-ng - 3.9.0
 
+[ Fabien Péan ]
+* CI: Enable job `windows_latest_cmake` to run all tests
+* CMake: Fix BLAS and LAPACK static library order needed to consume the library on Windows with static linkage
+
 [ Zhentao Wang ]
 * [BUG FIX] parpack.h and parpack.hpp: type of rwork should be real instead of complex.
 * Allow ritz_option {"LR", "SR", "LI", "SI"} for complex eigenvalue problems in ICB.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,10 @@ if (MPI)
         endif()
     endif()
 
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${MPI_Fortran_COMPILE_FLAG} -fallow-invalid-boz")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${MPI_Fortran_COMPILE_FLAG}")
+    if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-invalid-boz")
+    endif()
 
     # Check if we can use ISO_C_BINDING provided by MPI.
     file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/PROG_ICB.f90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ function(pexamples list_name)
         get_filename_component(lwe ${l} NAME_WE)
         add_executable(${lwe} ${parpackexample_DIR}/${l} )
         target_link_libraries(${lwe} parpack arpack MPI::MPI_Fortran)
-        add_test(NAME "${lwe}_ex" COMMAND mpirun -n 2 ./${lwe} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+        add_test(NAME "${lwe}_ex" COMMAND mpiexec -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${lwe})
     endforeach()
 endfunction(pexamples)
 
@@ -212,7 +212,7 @@ if (MPI)
         endif()
     endif()
 
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${MPI_Fortran_COMPILE_FLAG}")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${MPI_Fortran_COMPILE_FLAG} -fallow-invalid-boz")
 
     # Check if we can use ISO_C_BINDING provided by MPI.
     file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/PROG_ICB.f90
@@ -771,12 +771,12 @@ function(build_tests)
       add_executable(icb_parpack_c PARPACK/TESTS/MPI/icb_parpack_c.c)
       target_include_directories(icb_parpack_c PUBLIC ${PROJECT_SOURCE_DIR}/ICB MPI::MPI_C) # Get parpack.h mpi.h
       target_link_libraries(icb_parpack_c parpack arpack BLAS::BLAS LAPACK::LAPACK ${EXTRA_LDFLAGS} MPI::MPI_C)
-      add_test(icb_parpack_c_tst mpirun -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/icb_parpack_c)
+      add_test(icb_parpack_c_tst mpiexec -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/icb_parpack_c)
 
       add_executable(icb_parpack_cpp PARPACK/TESTS/MPI/icb_parpack_cpp.cpp)
       target_include_directories(icb_parpack_cpp PUBLIC ${PROJECT_SOURCE_DIR}/ICB MPI::MPI_CXX) # Get parpack.hpp mpi.h
       target_link_libraries(icb_parpack_cpp parpack arpack BLAS::BLAS LAPACK::LAPACK ${EXTRA_LDFLAGS} MPI::MPI_CXX)
-      add_test(icb_parpack_cpp_tst mpirun -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/icb_parpack_cpp)
+      add_test(icb_parpack_cpp_tst mpiexec -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/icb_parpack_cpp)
     endif()
   endif()
 endfunction(build_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ function(pexamples list_name)
         get_filename_component(lwe ${l} NAME_WE)
         add_executable(${lwe} ${parpackexample_DIR}/${l} )
         target_link_libraries(${lwe} parpack arpack MPI::MPI_Fortran)
-        add_test(NAME "${lwe}_ex" COMMAND mpirun -n 2 ./${lwe})
+        add_test(NAME "${lwe}_ex" COMMAND mpirun -n 2 ./${lwe} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
     endforeach()
 endfunction(pexamples)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ function(pexamples list_name)
         get_filename_component(lwe ${l} NAME_WE)
         add_executable(${lwe} ${parpackexample_DIR}/${l} )
         target_link_libraries(${lwe} parpack arpack MPI::MPI_Fortran)
-        add_test(NAME "${lwe}_ex" COMMAND mpirun -n 2 ./${lwe} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+        add_test(NAME "${lwe}_ex" COMMAND mpirun -n 2 ./${lwe})
     endforeach()
 endfunction(pexamples)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ function(examples list_name)
         get_filename_component(lwe ${l} NAME_WE)
         add_executable(${lwe} ${arpackexample_DIR}/${l} ${examples_EXTRA_SRCS})
         target_link_libraries(${lwe} arpack BLAS::BLAS LAPACK::LAPACK ${EXTRA_LDFLAGS})
-        add_test(NAME "${lwe}_ex" COMMAND ${lwe} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+        add_test(NAME "${lwe}_ex" COMMAND ${lwe})
     endforeach()
 endfunction(examples)
 


### PR DESCRIPTION
Binaries of examples were not able to find `libarpack.dll` and failing, while tests were passing. The main difference in CMakeLists was setting the working directory for examples and not for tests. The binaries are probably linked without an absolute path for the library and searching the DLL in local folder. Changing the working directory in CMake changed the search local path where the DLL is absent.

To fix using MPI examples on Windows, the following was necessary:

* Add flag `-fallow-invalid-boz` fixing false positive errors on comments, e.g.
  * >    87 | c  1. D.C. Sorensen, "Implicit Application of Polynomial Filters in
                Warning: missing terminating " character 
* Replace `mpirun` by standard `mpiexec`
* Fix working directory of tests for MPI binaries