### PR TITLE
Avoid removing macro `_CRT_USE_C_COMPLEX_H` if pre-existing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ arpack-ng - 3.9.0
 [ Fabien Péan ]
 * CI: Enable job `windows_latest_cmake` to run all tests
 * CMake: Fix BLAS and LAPACK static library order needed to consume the library on Windows with static linkage
+* Fix using ARPACK on Windows with MSVC compiler from C++17 onwards
 
 [ Zhentao Wang ]
 * [BUG FIX] parpack.h and parpack.hpp: type of rwork should be real instead of complex.

--- a/arpackdef.h.in
+++ b/arpackdef.h.in
@@ -14,9 +14,13 @@
 #define a_uint unsigned int
 #endif
 #ifdef _MSC_VER
+#ifndef _CRT_USE_C_COMPLEX_H
 #define _CRT_USE_C_COMPLEX_H
 #include <complex.h>
 #undef _CRT_USE_C_COMPLEX_H
+#else
+#include <complex.h>
+#endif
 #define a_fcomplex _Fcomplex
 #define a_dcomplex _Dcomplex
 #ifndef CMPLXF


### PR DESCRIPTION
Last changes unilaterally undefined the macro no matter if it existed before. To keep it transparent and without side effects for anyone potentially relying on it in some other ways, it is now undefining the macro only if it was not previously defined. 
