### PR TITLE
README: document where to find arpack user's guide.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ arpack-ng - 3.9.1
  * Rename icbexmm option into eigen option.
  * README: document how to use ICB.
  * [BUG FIX] arpackmm: fix restart.
+ * README: document where to find arpack user's guide.
 
  -- Franck Houssen <fghoussen@users.noreply.github.com> Sat, 11 Feb 2023 13:52:57 +0100
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,10 @@ Note: Make sure to update `CMAKE_MODULE_PATH` env variable (otheriwse, `find_pac
 
 ### FAQ
 
+- Where can I find ARPACK user's guide?
+
+  http://li.mit.edu/Archive/Activities/Archive/CourseWork/Ju_Li/MITCourses/18.335/Doc/ARPACK/Lehoucq97.pdf
+
 - Calling arpack's aupd methods returns `info = -9 - Starting vector is zero.`: why?
 
   Residuals are null. Try to set `resid` to small values (like epsilon machine magnitude) but *not exactly* zero.


### PR DESCRIPTION
## Pull request purpose

https://github.com/opencollab/arpack-ng/issues/401#issuecomment-1454895226 
> The original ARPACK site [rice.edu] is no longer accessible, unfortunately.
> The ARPACK manual (e.g. [here](http://li.mit.edu/Archive/Activities/Archive/CourseWork/Ju_Li/MITCourses/18.335/Doc/ARPACK/Lehoucq97.pdf)),

@sylvestre: do you prefer to git-add the pdf in the repo? In case the links gets unavailable in the future (like rice.edu is now - seems impossible from now to get original ARPACK / PARPACK tarballs)?