### PR TITLE
CI: Setup workflow for MinGW-w64 CLANG64

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -252,6 +252,16 @@ jobs:
           make check
   windows_latest_cmake:
     runs-on: windows-latest
+    name: MinGW-w64 ${{ matrix.msystem }} INTERFACE64=${{ matrix.int64 }}/MPI=${{ matrix.mpi }}
+    strategy:
+      fail-fast: false
+      matrix:
+        msystem: [ UCRT64, CLANG64]
+        int64: [ ON, OFF]
+        mpi: [ON, OFF]
+        exclude:
+          - int64: ON
+            mpi: ON
     defaults:
       run:
         # Use MSYS2 as default shell
@@ -261,19 +271,26 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           update: true
-          msystem: MINGW64
+          msystem: ${{ matrix.msystem }}
           install: >-
             base-devel
             git
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-gcc-fortran
-            mingw-w64-x86_64-openblas
-            mingw-w64-x86_64-msmpi
+          pacboy: >-
+            cmake:p
+            ninja:p
+            fc:p
+      - name: Install OpenBLAS and MS-MPI
+        run: |
+          if [[ ${{ matrix.int64 }} != ON ]]; then
+            pacboy -S openblas:p msmpi:p --noconfirm
+          else
+            pacboy -S openblas64:p --noconfirm
+          fi
       - name: Install MS-MPI (for mpiexec)
+        if: ${{ matrix.mpi == 'ON' }}
         uses: mpi4py/setup-mpi@v1
       - name: Clone and check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}} # Branch where changes are implemented.
@@ -284,10 +301,15 @@ jobs:
       - name: Run job
         run: |
           mkdir -p build && cd build
-          cmake -GNinja -DICB=ON -DEXAMPLES=ON -DMPI=ON ..
+          if [[ ${{ matrix.int64 }} == ON ]]; then
+            _blas_lib="-DBLAS_LIBRARIES=openblas_64"
+          fi
+          cmake -GNinja -DICB=ON -DEXAMPLES=ON -DMPI=${{ matrix.mpi }} -DINTERFACE64=${{ matrix.int64 }} ${_blas_lib} ..
           cmake --build . -v
       - name: Run tests
         run: |
-          export PATH="/c/Program Files/Microsoft MPI/Bin":$PATH # add mpiexec to msys2 path
+          if [[ ${{ matrix.mpi }} == ON ]]; then
+            export PATH="/c/Program Files/Microsoft MPI/Bin":$PATH # add mpiexec to msys2 path
+          fi
           cd build
           ctest --output-on-failure


### PR DESCRIPTION
## Pull request purpose

This setup CI workflow for MSYS2/CLANG64
It completes the work done in #412, The workflow was failing, but we fixed that issue.

## Detailed changes proposed in this pull request

- Setup CI workflow for MinGW-w64 CLANG64
- Test with MPI=ON/OFF
- Test with INTERFACE64=ON/OFF
