### PR TITLE
Update CMakeLists.txt , add mpiexec to issue46_tst run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -675,7 +675,7 @@ function(build_tests)
 
     add_executable(issue46 PARPACK/TESTS/MPI/issue46.f)
     target_link_libraries(issue46 parpack arpack BLAS::BLAS LAPACK::LAPACK ${EXTRA_LDFLAGS})
-    add_test(issue46_tst ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/issue46)
+    add_test(issue46_tst mpiexec -n 2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/issue46)
   endif()
 
   if(ICB)


### PR DESCRIPTION
## Pull request purpose

fixing issue46_tst run failure on certain systems

## Detailed changes proposed in this pull request
See https://github.com/opencollab/arpack-ng/issues/417
-
-
-
