### PR TITLE
Update pyarpack tests with SPD solvers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 arpack-ng - 3.9.1
 
 [ Fabien Péan ]
+ * pyarpack: Ensure that the matrix properties (symmetric/hermitian) fit the solver (CG/LDL) with which they are used in the tests 
  * [BUG FIX] Tests for PARPACK with C/C++ bindings icb_parpack_c and icb_parpack_cpp are now really parallel and split the problem across MPI processes.
 
 [ Szabolcs Horvát ]

--- a/EXAMPLES/PYARPACK/pyarpackDenseLDLT.py.in
+++ b/EXAMPLES/PYARPACK/pyarpackDenseLDLT.py.in
@@ -6,24 +6,22 @@ from pyarpack import denseLDLT as pyarpackSlv
 # Build laplacian.
 
 n = 4
-Aij = np.array([], dtype='complex128')
+Aij = np.array([], dtype='float64')
 for k in range(n):
     for l in range(n):
         if l == k:
-            Aij = np.append(Aij, np.complex128(complex( 200.,  200.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        elif l == k-1:
-            Aij = np.append(Aij, np.complex128(complex(-101., -101.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        elif l == k+1:
-            Aij = np.append(Aij, np.complex128(complex( -99.,  -99.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.float64( 200.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        elif l == k-1 or l == k+1:
+            Aij = np.append(Aij, np.float64(-100.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         else:
-            Aij = np.append(Aij, np.complex128(complex(   0.,    0.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.float64(   0.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
 for idx, val in enumerate(Aij):
     print("A[", idx, "] =", val)
 A = (Aij, False) # raw format: Aij values, row ordered (or not).
 
 # Get and tune arpack solver.
 
-arpackSlv = pyarpackSlv.complexDouble() # Caution: complexDouble <=> np.array(..., dtype='complex128')
+arpackSlv = pyarpackSlv.double() # Caution: double <=> np.array(..., dtype='float64')
 arpackSlv.verbose = 3 # Set to 0 to get a quiet solve.
 arpackSlv.debug = 1 # Set to 0 to get a quiet solve.
 arpackSlv.nbEV = 1
@@ -32,7 +30,7 @@ arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
 arpackSlv.slvOffset = 0.
 arpackSlv.slvScale = 1.
-arpackSlv.symPb = False
+arpackSlv.symPb = True
 
 # Solve eigen problem.
 
@@ -60,22 +58,19 @@ print("\n#######################################################################
 # Build laplacian.
 
 n = 8
-Aij = np.array([], dtype='complex64')
-Bij = np.array([], dtype='complex64')
+Aij = np.array([], dtype='float32')
+Bij = np.array([], dtype='float32')
 for k in range(n):
     for l in range(n):
         if l == k:
-            Aij = np.append(Aij, np.complex64(complex( 200.,  200.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.complex64(complex( 33.3,  33.3))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        elif l == k-1:
-            Aij = np.append(Aij, np.complex64(complex(-101., -101.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.complex64(complex( 16.6,  16.6))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        elif l == k+1:
-            Aij = np.append(Aij, np.complex64(complex( -99.,  -99.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.complex64(complex( 16.6,  16.6))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.float32( 200.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.float32( 33.3)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        elif l == k-1 or l == k+1:
+            Aij = np.append(Aij, np.float32(-100.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.float32( 16.6)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         else:
-            Aij = np.append(Aij, np.complex64(complex(   0.,    0.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.complex64(complex(   0.,    0.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.float32(   0.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.float32(   0.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
 for idx, val in enumerate(Aij):
     print("A[", idx, "] =", val)
 for idx, val in enumerate(Bij):
@@ -85,7 +80,7 @@ B = (Bij,  True) # raw format: Bij values, row ordered (or not).
 
 # Get and tune arpack solver.
 
-arpackSlv = pyarpackSlv.complexFloat() # Caution: complexFloat <=> np.array(..., dtype='complex64')
+arpackSlv = pyarpackSlv.float() # Caution: float <=> np.array(..., dtype='float32')
 arpackSlv.verbose = 3 # Set to 0 to get a quiet solve.
 arpackSlv.debug = 1 # Set to 0 to get a quiet solve.
 arpackSlv.nbEV = 2
@@ -95,7 +90,7 @@ arpackSlv.maxIt = 200
 arpackSlv.slvOffset = 0.
 arpackSlv.slvScale = 1.
 arpackSlv.sigmaReal = 1
-arpackSlv.symPb = False
+arpackSlv.symPb = True
 
 # Solve eigen problem.
 

--- a/EXAMPLES/PYARPACK/pyarpackDenseLUPP.py.in
+++ b/EXAMPLES/PYARPACK/pyarpackDenseLUPP.py.in
@@ -6,22 +6,24 @@ from pyarpack import denseLUPP as pyarpackSlv
 # Build laplacian.
 
 n = 4
-Aij = np.array([], dtype='float64')
+Aij = np.array([], dtype='complex128')
 for k in range(n):
     for l in range(n):
         if l == k:
-            Aij = np.append(Aij, np.float64( 200.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        elif l == k-1 or l == k+1:
-            Aij = np.append(Aij, np.float64(-100.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.complex128(complex( 200.,  200.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        elif l == k-1:
+            Aij = np.append(Aij, np.complex128(complex(-101., -101.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        elif l == k+1:
+            Aij = np.append(Aij, np.complex128(complex( -99.,  -99.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
         else:
-            Aij = np.append(Aij, np.float64(   0.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.complex128(complex(   0.,    0.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
 for idx, val in enumerate(Aij):
     print("A[", idx, "] =", val)
 A = (Aij, False) # raw format: Aij values, row ordered (or not).
 
 # Get and tune arpack solver.
 
-arpackSlv = pyarpackSlv.double() # Caution: double <=> np.array(..., dtype='float64')
+arpackSlv = pyarpackSlv.complexDouble() # Caution: complexDouble <=> np.array(..., dtype='complex128')
 arpackSlv.verbose = 3 # Set to 0 to get a quiet solve.
 arpackSlv.debug = 1 # Set to 0 to get a quiet solve.
 arpackSlv.nbEV = 1
@@ -29,6 +31,7 @@ arpackSlv.nbCV = 2*arpackSlv.nbEV + 1
 arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
 arpackSlv.slvPvtThd = 1.e-6
+arpackSlv.symPb = False
 
 # Solve eigen problem.
 
@@ -56,19 +59,22 @@ print("\n#######################################################################
 # Build laplacian.
 
 n = 8
-Aij = np.array([], dtype='float32')
-Bij = np.array([], dtype='float32')
+Aij = np.array([], dtype='complex64')
+Bij = np.array([], dtype='complex64')
 for k in range(n):
     for l in range(n):
         if l == k:
-            Aij = np.append(Aij, np.float32( 200.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.float32( 33.3)) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        elif l == k-1 or l == k+1:
-            Aij = np.append(Aij, np.float32(-100.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.float32( 16.6)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.complex64(complex( 200.,  200.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.complex64(complex( 33.3,  33.3))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        elif l == k-1:
+            Aij = np.append(Aij, np.complex64(complex(-101., -101.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.complex64(complex( 16.6,  16.6))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        elif l == k+1:
+            Aij = np.append(Aij, np.complex64(complex( -99.,  -99.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.complex64(complex( 16.6,  16.6))) # Casting value on append is MANDATORY or C++ won't get the expected type.
         else:
-            Aij = np.append(Aij, np.float32(   0.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.float32(   0.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.complex64(complex(   0.,    0.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.complex64(complex(   0.,    0.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
 for idx, val in enumerate(Aij):
     print("A[", idx, "] =", val)
 for idx, val in enumerate(Bij):
@@ -78,7 +84,7 @@ B = (Bij,  True) # raw format: Bij values, row ordered (or not).
 
 # Get and tune arpack solver.
 
-arpackSlv = pyarpackSlv.float() # Caution: float <=> np.array(..., dtype='float32')
+arpackSlv = pyarpackSlv.complexFloat() # Caution: complexFloat <=> np.array(..., dtype='complex64')
 arpackSlv.verbose = 3 # Set to 0 to get a quiet solve.
 arpackSlv.debug = 1 # Set to 0 to get a quiet solve.
 arpackSlv.nbEV = 2
@@ -87,6 +93,7 @@ arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
 arpackSlv.slvPvtThd = 1.e-6
 arpackSlv.sigmaReal = 1
+arpackSlv.symPb = False
 
 # Solve eigen problem.
 

--- a/EXAMPLES/PYARPACK/pyarpackSparseCGILU.py.in
+++ b/EXAMPLES/PYARPACK/pyarpackSparseCGILU.py.in
@@ -18,9 +18,9 @@ for k in range(n):
         if l == k:
             Aij = np.append(Aij, np.complex128(complex( 200.,  200.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
         if l == k-1:
-            Aij = np.append(Aij, np.complex128(complex(-101., -101.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.complex128(complex(-100., -100.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
         if l == k+1:
-            Aij = np.append(Aij, np.complex128(complex( -99.,  -99.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.complex128(complex( -100.,  100.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
 for k, l, Akl in zip(i, j, Aij):
     print("A[", k, ",", l, "] =", Akl)
 A = (n, i, j, Aij) # coo format: dimension, i 0-based indices, j 0-based indices, Aij values.
@@ -69,7 +69,6 @@ n = 8
 i = np.array([], dtype='@PYINT@')
 j = np.array([], dtype='@PYINT@')
 Aij = np.array([], dtype='complex64')
-Bij = np.array([], dtype='complex64')
 for k in range(n):
     for l in [k-1, k, k+1]:
         if l < 0 or l > n-1:
@@ -78,19 +77,13 @@ for k in range(n):
         j = np.append(j, np.@PYINT@(l+1)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         if l == k:
             Aij = np.append(Aij, np.complex64(complex( 200.,  200.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.complex64(complex( 33.3,  33.3))) # Casting value on append is MANDATORY or C++ won't get the expected type.
         if l == k-1:
-            Aij = np.append(Aij, np.complex64(complex(-101., -101.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.complex64(complex( 16.6,  16.6))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.complex64(complex(-100., -100.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
         if l == k+1:
-            Aij = np.append(Aij, np.complex64(complex( -99.,  -99.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.complex64(complex( 16.6,  16.6))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.complex64(complex( -100.,  100.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
 for k, l, Akl in zip(i, j, Aij):
     print("A[", k, ",", l, "] =", Akl)
-for k, l, Bkl in zip(i, j, Bij):
-    print("B[", k, ",", l, "] =", Bkl)
 A = (n, i, j, Aij) # coo format: dimension, i 1-based indices, j 1-based indices, Aij values.
-B = (n, i, j, Bij) # coo format: dimension, i 1-based indices, j 1-based indices, Bij values.
 
 # Get and tune arpack solver.
 
@@ -111,9 +104,9 @@ arpackSlv.symPb = False
 
 # Solve eigen problem.
 
-rc = arpackSlv.solve(A, B)
+rc = arpackSlv.solve(A)
 assert rc == 0, "bad solve"
-rc = arpackSlv.checkEigVec(A, B, 1.)
+rc = arpackSlv.checkEigVec(A)
 assert rc == 0, "bad checkEigVec"
 
 # Print out results (mode selected, eigen vectors, eigen values, ...).

--- a/EXAMPLES/PYARPACK/pyarpackSparseLDLT.py.in
+++ b/EXAMPLES/PYARPACK/pyarpackSparseLDLT.py.in
@@ -8,7 +8,7 @@ from pyarpack import sparseLDLT as pyarpackSlv
 n = 4
 i = np.array([], dtype='@PYINT@')
 j = np.array([], dtype='@PYINT@')
-Aij = np.array([], dtype='complex128')
+Aij = np.array([], dtype='float64')
 for k in range(n):
     for l in [k-1, k, k+1]:
         if l < 0 or l > n-1:
@@ -16,27 +16,23 @@ for k in range(n):
         i = np.append(i, np.@PYINT@(k)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         j = np.append(j, np.@PYINT@(l)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         if l == k:
-            Aij = np.append(Aij, np.complex128(complex( 200.,  200.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        if l == k-1:
-            Aij = np.append(Aij, np.complex128(complex(-101., -101.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        if l == k+1:
-            Aij = np.append(Aij, np.complex128(complex( -99.,  -99.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.float64( 200.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        if l == k-1 or l == k+1:
+            Aij = np.append(Aij, np.float64(-100.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
 for k, l, Akl in zip(i, j, Aij):
     print("A[", k, ",", l, "] =", Akl)
 A = (n, i, j, Aij) # coo format: dimension, i 0-based indices, j 0-based indices, Aij values.
 
 # Get and tune arpack solver.
 
-arpackSlv = pyarpackSlv.complexDouble() # Caution: complexDouble <=> np.array(..., dtype='complex128')
+arpackSlv = pyarpackSlv.double() # Caution: double <=> np.array(..., dtype='float64')
 arpackSlv.verbose = 3 # Set to 0 to get a quiet solve.
 arpackSlv.debug = 1 # Set to 0 to get a quiet solve.
 arpackSlv.nbEV = 1
 arpackSlv.nbCV = 2*arpackSlv.nbEV + 1
 arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
-arpackSlv.slvOffset = 0.
-arpackSlv.slvScale = 1.
-arpackSlv.symPb = False
+arpackSlv.slvPvtThd = 1.e-6
 
 # Solve eigen problem.
 
@@ -66,8 +62,8 @@ print("\n#######################################################################
 n = 8
 i = np.array([], dtype='@PYINT@')
 j = np.array([], dtype='@PYINT@')
-Aij = np.array([], dtype='complex64')
-Bij = np.array([], dtype='complex64')
+Aij = np.array([], dtype='float32')
+Bij = np.array([], dtype='float32')
 for k in range(n):
     for l in [k-1, k, k+1]:
         if l < 0 or l > n-1:
@@ -75,14 +71,11 @@ for k in range(n):
         i = np.append(i, np.@PYINT@(k+1)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         j = np.append(j, np.@PYINT@(l+1)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         if l == k:
-            Aij = np.append(Aij, np.complex64(complex( 200.,  200.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.complex64(complex( 33.3,  33.3))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        if l == k-1:
-            Aij = np.append(Aij, np.complex64(complex(-101., -101.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.complex64(complex( 16.6,  16.6))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        if l == k+1:
-            Aij = np.append(Aij, np.complex64(complex( -99.,  -99.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.complex64(complex( 16.6,  16.6))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.float32( 200.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.float32( 33.3)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        if l == k-1 or l == k+1:
+            Aij = np.append(Aij, np.float32(-100.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.float32( 16.6)) # Casting value on append is MANDATORY or C++ won't get the expected type.
 for k, l, Akl in zip(i, j, Aij):
     print("A[", k, ",", l, "] =", Akl)
 for k, l, Bkl in zip(i, j, Bij):
@@ -92,18 +85,15 @@ B = (n, i, j, Bij) # coo format: dimension, i 1-based indices, j 1-based indices
 
 # Get and tune arpack solver.
 
-arpackSlv = pyarpackSlv.complexFloat() # Caution: complexFloat <=> np.array(..., dtype='complex64')
+arpackSlv = pyarpackSlv.float() # Caution: float <=> np.array(..., dtype='float32')
 arpackSlv.verbose = 3 # Set to 0 to get a quiet solve.
 arpackSlv.debug = 1 # Set to 0 to get a quiet solve.
 arpackSlv.nbEV = 2
 arpackSlv.nbCV = 2*arpackSlv.nbEV + 1
 arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
-arpackSlv.slvOffset = 0.
-arpackSlv.slvScale = 1.
+arpackSlv.slvPvtThd = 1.e-6
 arpackSlv.sigmaReal = 1
-arpackSlv.sigmaImag = 1
-arpackSlv.symPb = False
 
 # Solve eigen problem.
 

--- a/EXAMPLES/PYARPACK/pyarpackSparseLDLT.py.in
+++ b/EXAMPLES/PYARPACK/pyarpackSparseLDLT.py.in
@@ -32,7 +32,9 @@ arpackSlv.nbEV = 1
 arpackSlv.nbCV = 2*arpackSlv.nbEV + 1
 arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
-arpackSlv.slvPvtThd = 1.e-6
+arpackSlv.slvOffset = 0.
+arpackSlv.slvScale = 1.
+arpackSlv.symPb = True
 
 # Solve eigen problem.
 
@@ -92,8 +94,10 @@ arpackSlv.nbEV = 2
 arpackSlv.nbCV = 2*arpackSlv.nbEV + 1
 arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
-arpackSlv.slvPvtThd = 1.e-6
+arpackSlv.slvOffset = 0.
+arpackSlv.slvScale = 1.
 arpackSlv.sigmaReal = 1
+arpackSlv.symPb = True
 
 # Solve eigen problem.
 

--- a/EXAMPLES/PYARPACK/pyarpackSparseLU.py.in
+++ b/EXAMPLES/PYARPACK/pyarpackSparseLU.py.in
@@ -2,13 +2,12 @@
 
 import numpy as np
 from pyarpack import sparseLU as pyarpackSlv
-
 # Build laplacian.
 
 n = 4
 i = np.array([], dtype='@PYINT@')
 j = np.array([], dtype='@PYINT@')
-Aij = np.array([], dtype='float64')
+Aij = np.array([], dtype='complex128')
 for k in range(n):
     for l in [k-1, k, k+1]:
         if l < 0 or l > n-1:
@@ -16,23 +15,27 @@ for k in range(n):
         i = np.append(i, np.@PYINT@(k)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         j = np.append(j, np.@PYINT@(l)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         if l == k:
-            Aij = np.append(Aij, np.float64( 200.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        if l == k-1 or l == k+1:
-            Aij = np.append(Aij, np.float64(-100.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.complex128(complex( 200.,  200.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        if l == k-1:
+            Aij = np.append(Aij, np.complex128(complex(-101., -101.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        if l == k+1:
+            Aij = np.append(Aij, np.complex128(complex( -99.,  -99.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
 for k, l, Akl in zip(i, j, Aij):
     print("A[", k, ",", l, "] =", Akl)
 A = (n, i, j, Aij) # coo format: dimension, i 0-based indices, j 0-based indices, Aij values.
 
 # Get and tune arpack solver.
 
-arpackSlv = pyarpackSlv.double() # Caution: double <=> np.array(..., dtype='float64')
+arpackSlv = pyarpackSlv.complexDouble() # Caution: complexDouble <=> np.array(..., dtype='complex128')
 arpackSlv.verbose = 3 # Set to 0 to get a quiet solve.
 arpackSlv.debug = 1 # Set to 0 to get a quiet solve.
 arpackSlv.nbEV = 1
 arpackSlv.nbCV = 2*arpackSlv.nbEV + 1
 arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
-arpackSlv.slvPvtThd = 1.e-6
+arpackSlv.slvOffset = 0.
+arpackSlv.slvScale = 1.
+arpackSlv.symPb = False
 
 # Solve eigen problem.
 
@@ -62,8 +65,8 @@ print("\n#######################################################################
 n = 8
 i = np.array([], dtype='@PYINT@')
 j = np.array([], dtype='@PYINT@')
-Aij = np.array([], dtype='float32')
-Bij = np.array([], dtype='float32')
+Aij = np.array([], dtype='complex64')
+Bij = np.array([], dtype='complex64')
 for k in range(n):
     for l in [k-1, k, k+1]:
         if l < 0 or l > n-1:
@@ -71,11 +74,14 @@ for k in range(n):
         i = np.append(i, np.@PYINT@(k+1)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         j = np.append(j, np.@PYINT@(l+1)) # Casting value on append is MANDATORY or C++ won't get the expected type.
         if l == k:
-            Aij = np.append(Aij, np.float32( 200.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.float32( 33.3)) # Casting value on append is MANDATORY or C++ won't get the expected type.
-        if l == k-1 or l == k+1:
-            Aij = np.append(Aij, np.float32(-100.)) # Casting value on append is MANDATORY or C++ won't get the expected type.
-            Bij = np.append(Bij, np.float32( 16.6)) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Aij = np.append(Aij, np.complex64(complex( 200.,  200.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.complex64(complex( 33.3,  33.3))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        if l == k-1:
+            Aij = np.append(Aij, np.complex64(complex(-101., -101.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.complex64(complex( 16.6,  16.6))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+        if l == k+1:
+            Aij = np.append(Aij, np.complex64(complex( -99.,  -99.))) # Casting value on append is MANDATORY or C++ won't get the expected type.
+            Bij = np.append(Bij, np.complex64(complex( 16.6,  16.6))) # Casting value on append is MANDATORY or C++ won't get the expected type.
 for k, l, Akl in zip(i, j, Aij):
     print("A[", k, ",", l, "] =", Akl)
 for k, l, Bkl in zip(i, j, Bij):
@@ -85,15 +91,18 @@ B = (n, i, j, Bij) # coo format: dimension, i 1-based indices, j 1-based indices
 
 # Get and tune arpack solver.
 
-arpackSlv = pyarpackSlv.float() # Caution: float <=> np.array(..., dtype='float32')
+arpackSlv = pyarpackSlv.complexFloat() # Caution: complexFloat <=> np.array(..., dtype='complex64')
 arpackSlv.verbose = 3 # Set to 0 to get a quiet solve.
 arpackSlv.debug = 1 # Set to 0 to get a quiet solve.
 arpackSlv.nbEV = 2
 arpackSlv.nbCV = 2*arpackSlv.nbEV + 1
 arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
-arpackSlv.slvPvtThd = 1.e-6
+arpackSlv.slvOffset = 0.
+arpackSlv.slvScale = 1.
 arpackSlv.sigmaReal = 1
+arpackSlv.sigmaImag = 1
+arpackSlv.symPb = False
 
 # Solve eigen problem.
 

--- a/EXAMPLES/PYARPACK/pyarpackSparseLU.py.in
+++ b/EXAMPLES/PYARPACK/pyarpackSparseLU.py.in
@@ -33,8 +33,7 @@ arpackSlv.nbEV = 1
 arpackSlv.nbCV = 2*arpackSlv.nbEV + 1
 arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
-arpackSlv.slvOffset = 0.
-arpackSlv.slvScale = 1.
+arpackSlv.slvPvtThd = 1.e-6
 arpackSlv.symPb = False
 
 # Solve eigen problem.
@@ -98,8 +97,7 @@ arpackSlv.nbEV = 2
 arpackSlv.nbCV = 2*arpackSlv.nbEV + 1
 arpackSlv.mag = 'LM'
 arpackSlv.maxIt = 200
-arpackSlv.slvOffset = 0.
-arpackSlv.slvScale = 1.
+arpackSlv.slvPvtThd = 1.e-6
 arpackSlv.sigmaReal = 1
 arpackSlv.sigmaImag = 1
 arpackSlv.symPb = False


### PR DESCRIPTION
My proposal for fixing #432 

* Swapping matrices `pyarpackSparseLDLT` &lrarr; `pyarpackSparseLU`
* Swapping matrices `pyarpackDenseLDLT` &lrarr; `pyarpackDenseLUPP`
* `pyarpackCGILU` solves for hermitian matrices (and only non-general due to risk of losing positive definitness with shift-inverse)