### PR TITLE
Update RNG seed initialization in PARPACK

### DIFF
--- a/PARPACK/SRC/MPI/pcgetv0.f
+++ b/PARPACK/SRC/MPI/pcgetv0.f
@@ -177,9 +177,9 @@ c     | Local Scalars & Arrays |
 c     %------------------------%
 c
       logical    first, inits, orth
-      integer    idist, iseed(4), iter, msglvl, jj, myid, igen
+      integer    idist, iseed(4), iter, msglvl, jj, myid
       Real
-     &           rnorm0
+     &           rnorm0, rseed(4)
       Complex
      &           cnorm, cnorm2
       save       first, iseed, inits, iter, msglvl, orth, rnorm0
@@ -214,32 +214,29 @@ c     | Executable Statements |
 c     %-----------------------%
 c
 c
+      if (inits) then
+c
 c     %-----------------------------------%
 c     | Initialize the seed of the LAPACK |
 c     | random number generator           |
+c     | Note: seed array elements must be |
+c     | between 0 and 4095 (12-bit coded) |
+c     | iseed(4) must be odd              |
 c     %-----------------------------------%
 c
-      if (inits) then
-c
-c        %-----------------------------------%
-c        | Generate a seed on each processor |
-c        | using process id (myid).          |
-c        | Note: the seed must be between 1  |
-c        | and 4095.  iseed(4) must be odd.  |
-c        %-----------------------------------%
-c
          call MPI_COMM_RANK(comm, myid, ierr)
-         igen = 1000 + 2*myid + 1
-         if (igen .gt. 4095) then
-            write(0,*) 'Error in p_getv0: seed exceeds 4095!'
-         end if
 c
-         iseed(1) = igen/1000
-         igen     = mod(igen,1000)
-         iseed(2) = igen/100
-         igen     = mod(igen,100)
-         iseed(3) = igen/10
-         iseed(4) = mod(igen,10)
+         iseed(1) = 1
+         iseed(2) = 3
+         iseed(3) = 5
+         iseed(4) = 7
+         do I = 0,myid
+            call slarnv(1,iseed,4,rseed)
+         end do
+         iseed(1) = NINT(rseed(1)*4095)
+         iseed(2) = NINT(rseed(2)*4095)
+         iseed(3) = NINT(rseed(3)*4095)
+         iseed(4) = 1+2*NINT(rseed(4)*2048)
 c
          inits = .false.
       end if

--- a/PARPACK/SRC/MPI/pdgetv0.f
+++ b/PARPACK/SRC/MPI/pdgetv0.f
@@ -178,9 +178,9 @@ c     | Local Scalars & Arrays |
 c     %------------------------%
 c
       logical    first, inits, orth
-      integer    idist, iseed(4), iter, msglvl, jj, myid, igen
+      integer    idist, iseed(4), iter, msglvl, jj, myid
       Double precision
-     &           rnorm0, buf2(1)
+     &           rnorm0, buf2(1), rseed(4)
       save       first, iseed, inits, iter, msglvl, orth, rnorm0
 c
       Double precision
@@ -217,32 +217,29 @@ c     | Executable Statements |
 c     %-----------------------%
 c
 c
+      if (inits) then
+c
 c     %-----------------------------------%
 c     | Initialize the seed of the LAPACK |
 c     | random number generator           |
+c     | Note: seed array elements must be |
+c     | between 0 and 4095 (12-bit coded) |
+c     | iseed(4) must be odd              |
 c     %-----------------------------------%
 c
-      if (inits) then
-c
-c        %-----------------------------------%
-c        | Generate a seed on each processor |
-c        | using process id (myid).          |
-c        | Note: the seed must be between 1  |
-c        | and 4095.  iseed(4) must be odd.  |
-c        %-----------------------------------%
-c
          call MPI_COMM_RANK(comm, myid, ierr)
-         igen = 1000 + 2*myid + 1
-         if (igen .gt. 4095) then
-            write(0,*) 'Error in p_getv0: seed exceeds 4095!'
-         end if
 c
-         iseed(1) = igen/1000
-         igen     = mod(igen,1000)
-         iseed(2) = igen/100
-         igen     = mod(igen,100)
-         iseed(3) = igen/10
-         iseed(4) = mod(igen,10)
+         iseed(1) = 1
+         iseed(2) = 3
+         iseed(3) = 5
+         iseed(4) = 7
+         do I = 0,myid
+            call dlarnv(1,iseed,4,rseed)
+         end do
+         iseed(1) = NINT(rseed(1)*4095)
+         iseed(2) = NINT(rseed(2)*4095)
+         iseed(3) = NINT(rseed(3)*4095)
+         iseed(4) = 1+2*NINT(rseed(4)*2048)
 c
          inits = .false.
       end if

--- a/PARPACK/SRC/MPI/psgetv0.f
+++ b/PARPACK/SRC/MPI/psgetv0.f
@@ -178,9 +178,9 @@ c     | Local Scalars & Arrays |
 c     %------------------------%
 c
       logical    first, inits, orth
-      integer    idist, iseed(4), iter, msglvl, jj, myid, igen
+      integer    idist, iseed(4), iter, msglvl, jj, myid
       Real
-     &           rnorm0
+     &           rnorm0, rseed(4)
       save       first, iseed, inits, iter, msglvl, orth, rnorm0
 c
       Real
@@ -219,25 +219,27 @@ c
 c
       if (inits) then
 c
-c        %-----------------------------------%
-c        | Generate a seed on each processor |
-c        | using process id (myid).          |
-c        | Note: the seed must be between 1  |
-c        | and 4095.  iseed(4) must be odd.  |
-c        %-----------------------------------%
+c     %-----------------------------------%
+c     | Initialize the seed of the LAPACK |
+c     | random number generator           |
+c     | Note: seed array elements must be |
+c     | between 0 and 4095 (12-bit coded) |
+c     | iseed(4) must be odd              |
+c     %-----------------------------------%
 c
          call MPI_COMM_RANK(comm, myid, ierr)
-         igen = 1000 + 2*myid + 1
-         if (igen .gt. 4095) then
-            write(0,*) 'Error in p_getv0: seed exceeds 4095!'
-         end if
 c
-         iseed(1) = igen/1000
-         igen     = mod(igen,1000)
-         iseed(2) = igen/100
-         igen     = mod(igen,100)
-         iseed(3) = igen/10
-         iseed(4) = mod(igen,10)
+         iseed(1) = 1
+         iseed(2) = 3
+         iseed(3) = 5
+         iseed(4) = 7
+         do I = 0,myid
+            call slarnv(1,iseed,4,rseed)
+         end do
+         iseed(1) = NINT(rseed(1)*4095)
+         iseed(2) = NINT(rseed(2)*4095)
+         iseed(3) = NINT(rseed(3)*4095)
+         iseed(4) = 1+2*NINT(rseed(4)*2048)
 c
          inits = .false.
       end if

--- a/PARPACK/SRC/MPI/pzgetv0.f
+++ b/PARPACK/SRC/MPI/pzgetv0.f
@@ -177,9 +177,9 @@ c     | Local Scalars & Arrays |
 c     %------------------------%
 c
       logical    first, inits, orth
-      integer    idist, iseed(4), iter, msglvl, jj, myid, igen
+      integer    idist, iseed(4), iter, msglvl, jj, myid
       Double precision
-     &           rnorm0
+     &           rnorm0, rseed(4)
       Complex*16
      &           cnorm, cnorm2
       save       first, iseed, inits, iter, msglvl, orth, rnorm0
@@ -214,32 +214,29 @@ c     | Executable Statements |
 c     %-----------------------%
 c
 c
+      if (inits) then
+c
 c     %-----------------------------------%
 c     | Initialize the seed of the LAPACK |
 c     | random number generator           |
+c     | Note: seed array elements must be |
+c     | between 0 and 4095 (12-bit coded) |
+c     | iseed(4) must be odd              |
 c     %-----------------------------------%
 c
-      if (inits) then
-c
-c        %-----------------------------------%
-c        | Generate a seed on each processor |
-c        | using process id (myid).          |
-c        | Note: the seed must be between 1  |
-c        | and 4095.  iseed(4) must be odd.  |
-c        %-----------------------------------%
-c
          call MPI_COMM_RANK(comm, myid, ierr)
-         igen = 1000 + 2*myid + 1
-         if (igen .gt. 4095) then
-            write(0,*) 'Error in p_getv0: seed exceeds 4095!'
-         end if
 c
-         iseed(1) = igen/1000
-         igen     = mod(igen,1000)
-         iseed(2) = igen/100
-         igen     = mod(igen,100)
-         iseed(3) = igen/10
-         iseed(4) = mod(igen,10)
+         iseed(1) = 1
+         iseed(2) = 3
+         iseed(3) = 5
+         iseed(4) = 7
+         do I = 0,myid
+            call dlarnv(1,iseed,4,rseed)
+         end do
+         iseed(1) = NINT(rseed(1)*4095)
+         iseed(2) = NINT(rseed(2)*4095)
+         iseed(3) = NINT(rseed(3)*4095)
+         iseed(4) = 1+2*NINT(rseed(4)*2048)
 c
          inits = .false.
       end if


### PR DESCRIPTION
Following-up and trying to wrap-up #431. Taking into account the elements raised by https://github.com/opencollab/arpack-ng/pull/431#issuecomment-1705620924 using basic tools.

Does this change seems appropriate to you @szhorvat @fghoussen ?

Each seed is initialized from a random generator coming from a master seed by running `myid` times the RNG. For a given seed, successive call to the generator should produce an independent sequence according the info, then converting those number to fit within the LAPACK seed constraints.