### PR TITLE
Quote the default pkgconfigdir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -342,7 +342,7 @@ AM_CONDITIONAL([BLACS], [false])
 AM_CONDITIONAL([ICB], [test x"$enable_icb" != x"no"])
 AM_CONDITIONAL([EIGEN], [test x"$enable_eigen" != x"no"])
 
-m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR], [AC_SUBST([pkgconfigdir], [${libdir}/pkgconfig])])
+m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR], [AC_SUBST([pkgconfigdir], ['${libdir}/pkgconfig'])])
 AC_SUBST([ARPACK_PC_LIBS_PRIVATE], ["$LAPACK_LIBS $BLAS_LIBS"])
 AC_SUBST([PARPACK_PC_LIBS_PRIVATE], ["$LAPACK_LIBS $BLAS_LIBS $MPI_Fortran_LIBS"])
 


### PR DESCRIPTION
The second argument to `AC_SUBST` is placed on the right-hand-side of a shell variable assignment.  Without the single quotes, `${libdir}` is expanded when that variable assignment is executed, which is earlier than we want.

Discovered while testing #183, when `pkg.m4` is missing or too old.