### PR TITLE
Build all PARPACK files with optimization

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[ Kyle Guinn ]
+ * Build PARPACK p[sd]lamch10.f with FFLAGS from ./configure instead of forcing -O0.  Build all of PARPACK with AM_FFLAGS.
+
 arpack-ng - 3.9.1
 
 [ Fabien Péan ]

--- a/PARPACK/SRC/MPI/Makefile.am
+++ b/PARPACK/SRC/MPI/Makefile.am
@@ -1,17 +1,15 @@
 AUTOMAKE_OPTIONS = subdir-objects # Needed as debug/stat* are not in current directory.
 
 F77 = $(MPIF77)
-FFLAGS_SAV = @FFLAGS@
-FFLAGS =
 
 PSRC = pcontext.f
 SSRC = psnaitr.f psnapps.f psnaup2.f psnaupd.f psneigh.f psneupd.f psngets.f \
        pssaitr.f pssapps.f pssaup2.f pssaupd.f psseigt.f psseupd.f pssgets.f \
-       psgetv0.f pslarnv.f psnorm2.f
+       psgetv0.f pslarnv.f psnorm2.f pslamch10.f
 
 DSRC = pdnaitr.f pdnapps.f pdnaup2.f pdnaupd.f pdneigh.f pdneupd.f pdngets.f \
        pdsaitr.f pdsapps.f pdsaup2.f pdsaupd.f pdseigt.f pdseupd.f pdsgets.f \
-       pdgetv0.f pdlarnv.f pdnorm2.f
+       pdgetv0.f pdlarnv.f pdnorm2.f pdlamch10.f
 
 CSRC = pcnaitr.f pcnapps.f pcnaup2.f pcnaupd.f pcneigh.f pcneupd.f pcngets.f \
        pcgetv0.f pclarnv.f pscnorm2.f
@@ -28,16 +26,11 @@ endif
 
 EXTRA_DIST = debug.h stat.h pcontext.h
 
-noinst_LTLIBRARIES = libparpack@LIBSUFFIX@@ITF64SUFFIX@_noopt.la
-libparpack@LIBSUFFIX@@ITF64SUFFIX@_noopt_la_SOURCES = pslamch10.f pdlamch10.f
-libparpack@LIBSUFFIX@@ITF64SUFFIX@_noopt_la_FFLAGS = -O0
-
 lib_LTLIBRARIES = libparpack@LIBSUFFIX@@ITF64SUFFIX@.la
 libparpack@LIBSUFFIX@@ITF64SUFFIX@_la_SOURCES = $(PSRC) $(SSRC) $(DSRC) $(CSRC) $(ZSRC)
 libparpack@LIBSUFFIX@@ITF64SUFFIX@_la_SOURCES += $(top_builddir)/dbgini.f
 libparpack@LIBSUFFIX@@ITF64SUFFIX@_la_SOURCES += $(top_builddir)/staini.f
-libparpack@LIBSUFFIX@@ITF64SUFFIX@_la_FFLAGS = $(FFLAGS_SAV)
-libparpack@LIBSUFFIX@@ITF64SUFFIX@_la_LIBADD = libparpack@LIBSUFFIX@@ITF64SUFFIX@_noopt.la \
+libparpack@LIBSUFFIX@@ITF64SUFFIX@_la_LIBADD = \
 	$(top_builddir)/PARPACK/UTIL/MPI/libparpackutil.la \
 	$(top_builddir)/SRC/libarpack@LIBSUFFIX@@ITF64SUFFIX@.la \
 	$(LAPACK_LIBS) $(BLAS_LIBS) $(MPI_Fortran_LIBS)


### PR DESCRIPTION
Alternate solution to #448.  See discussion on #449.

@loqs Try this, I think all FFLAGS will be present.