### PR TITLE
Add CI runners on emulated hardware

### DIFF
--- a/.github/workflows/emulated.yml
+++ b/.github/workflows/emulated.yml
@@ -1,0 +1,68 @@
+name: arch-emu
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+concurrency: ci-arch-emu-${{ github.ref }}
+
+jobs:
+
+  alpine:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        # Use emulated shell as default
+        shell: alpine.sh {0}
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        # For available CPU architectures, see:
+        # https://github.com/marketplace/actions/setup-alpine-linux-environment
+        arch: [x86, aarch64, armv7, ppc64le, riscv64, s390x]
+
+    name: alpine (${{ matrix.arch }})
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: install dependencies
+        uses: jirutka/setup-alpine@v1
+        with:
+          arch: ${{ matrix.arch }}
+          packages: >
+            bash
+            build-base
+            cmake
+            gfortran
+            eigen-dev
+            lapack-dev
+
+      - name: configure
+        run: |
+          echo "gcc --version"
+          gcc --version
+          echo "gcc -dumpmachine"
+          gcc -dumpmachine
+          mkdir -p ${GITHUB_WORKSPACE}/build && cd ${GITHUB_WORKSPACE}/build
+          cmake \
+            -DEXAMPLES=ON \
+            -DMPI=OFF \
+            -DICB=ON \
+            -DEIGEN=ON \
+            ..
+
+      - name: build
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          cmake --build .
+
+      - name: test
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          ctest . || ctest . --rerun-failed --output-on-failure

--- a/.github/workflows/emulated.yml
+++ b/.github/workflows/emulated.yml
@@ -38,10 +38,40 @@ jobs:
           packages: >
             bash
             build-base
+            ccache
             cmake
             gfortran
             eigen-dev
             lapack-dev
+
+      - name: prepare ccache
+        # create key with human readable timestamp
+        # used in action/cache/restore and action/cache/save steps
+        id: ccache-prepare
+        run: |
+          echo "key=ccache:alpine:${{ matrix.arch }}:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
+
+      - name: restore ccache
+        # setup the GitHub cache used to maintain the ccache from one job to the next
+        uses: actions/cache/restore@v4
+        with:
+          # location of the ccache of the chroot in the root file system
+          path: /home/runner/rootfs/alpine-latest-${{ matrix.arch }}/home/runner/.ccache
+          key: ${{ steps.ccache-prepare.outputs.key }}
+          # Prefer caches from the same branch. Fall back to caches from the default branch.
+          restore-keys: |
+            ccache:alpine:${{ matrix.arch }}:${{ github.ref }}
+            ccache:alpine:${{ matrix.arch }}
+
+      - name: configure ccache
+        env:
+          CCACHE_MAX: ${{ matrix.ccache-max }}
+        run: |
+          test -d ~/.ccache || mkdir ~/.ccache
+          echo "max_size = 20M" >> ~/.ccache/ccache.conf
+          echo "compression = true" >> ~/.ccache/ccache.conf
+          ccache -s
+          which ccache
 
       - name: configure
         run: |
@@ -49,18 +79,33 @@ jobs:
           gcc --version
           echo "gcc -dumpmachine"
           gcc -dumpmachine
+          echo " "
           mkdir -p ${GITHUB_WORKSPACE}/build && cd ${GITHUB_WORKSPACE}/build
           cmake \
             -DEXAMPLES=ON \
             -DMPI=OFF \
             -DICB=ON \
             -DEIGEN=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
+            -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
             ..
 
       - name: build
         run: |
           cd ${GITHUB_WORKSPACE}/build
           cmake --build .
+
+      - name: ccache status
+        continue-on-error: true
+        run: ccache -s
+
+      - name: save ccache
+        # Save the cache after we are done (successfully) building
+        # This helps to retain the ccache even if the subsequent steps are failing.
+        uses: actions/cache/save@v4
+        with:
+          path: /home/runner/rootfs/alpine-latest-${{ matrix.arch }}/home/runner/.ccache
+          key: ${{ steps.ccache-prepare.outputs.key }}
 
       - name: test
         run: |


### PR DESCRIPTION
## Pull request purpose

Use a GitHub action to install Alpine Linux for different, less common architectures that are emulated with qemu (apart from x86).
Additionally, Alpine Linux is one of those distributions that are based on musl (instead of glibc).

This increases coverage for different configurations in CI.

## Detailed changes proposed in this pull request

This PR adds GitHub action runners that build on Alpine Linux. It uses an action from the GitHub marketplace to install the required packages and set up `qemu` for subsequent steps (if necessary to emulate the respective architecture).

The emulated hardware can be slow. Especially compiling C++ objects seems to take quite some time. In preliminary tests, building ARPACK in the given configuration on emulated hardware took about 30 minutes.
This PR uses `ccache` to try to mitigate that. In preliminary tests, building with a hot cache reduced the build time to about 10 minutes on emulated hardware.
Unfortunately, current versions of `ccache` aren't able to cache Fortran objects. So, it is only used for the C and C++ objects.

To reduce the minutes that are used by this action, a concurrency rule is used to skip running the action if changes are pushed in quick succession.
