### PR TITLE
CI: Add CI for CLANG64 environment of MSYS2

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -324,10 +324,29 @@ jobs:
           cmake --build . -v
           echo "::endgroup::"
       - name: Run tests
+        id: run-ctest
         run: |
           if [[ ${{ matrix.mpi }} == ON ]]; then
             export PATH="/c/Program Files/Microsoft MPI/Bin":$PATH # add mpiexec to msys2 path
           fi
           export PATH="${GITHUB_WORKSPACE}/build":$PATH # add libarpack.dll to msys2 path for tests that run in different directory
           cd build
-          ctest --output-on-failure
+          ctest
+      - name: Re-run tests
+        if: always() && (steps.run-ctest.outcome == 'failure')
+        timeout-minutes: 60
+        run: |
+          if [[ ${{ matrix.mpi }} == ON ]]; then
+            export PATH="/c/Program Files/Microsoft MPI/Bin":$PATH # add mpiexec to msys2 path
+          fi
+          export PATH="${GITHUB_WORKSPACE}/build":$PATH # add libarpack.dll to msys2 path for tests that run in different directory
+          cd build
+          echo "::group::Re-run ctest"
+          ctest --rerun-failed --output-on-failure || true
+          echo "::endgroup::"
+          echo "::group::Log from these tests"
+          [ ! -f Testing/Temporary/LastTest.log ] || cat Testing/Temporary/LastTest.log
+          echo "::endgroup::"
+          echo "::group::Content of arpackmm.run.log"
+          [ ! -f EXAMPLES/MATRIX_MARKET/arpackmm.run.log ] || cat EXAMPLES/MATRIX_MARKET/arpackmm.run.log
+          echo "::endgroup::"

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -251,6 +251,16 @@ jobs:
           make check
   windows_latest_cmake:
     runs-on: windows-latest
+    name: MinGW-w64 ${{ matrix.msystem }} INTERFACE64=${{ matrix.int64 }}/MPI=${{ matrix.mpi }}
+    strategy:
+      fail-fast: false
+      matrix:
+        msystem: [UCRT64, CLANG64]
+        int64: [ON, OFF]
+        mpi: [ON, OFF]
+        exclude:
+          - int64: ON
+            mpi: ON
     defaults:
       run:
         # Use MSYS2 as default shell
@@ -260,15 +270,27 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           update: true
-          msystem: MINGW64
+          msystem: ${{ matrix.msystem }}
           install: >-
             base-devel
             git
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-gcc-fortran
-            mingw-w64-x86_64-openblas
-            mingw-w64-x86_64-msmpi
+          pacboy: >-
+            cmake:p
+            ninja:p
+            cc:p
+            fc:p
+      - name: Install OpenBLAS and MS-MPI from MSYS2
+        run: |
+          if [[ ${{ matrix.int64 }} != ON ]]; then
+            pacboy -S openblas:p --noconfirm
+          else
+            pacboy -S openblas64:p --noconfirm
+          fi
+          if [[ ${{ matrix.mpi }} = ON ]]; then
+            # This installs only the link library.
+            # The actual library will be installed in the next step.
+            pacboy -S msmpi:p --noconfirm
+          fi
       - name: Install MS-MPI (for mpiexec)
         uses: mpi4py/setup-mpi@v1
       - name: Clone and check out repository code
@@ -283,10 +305,26 @@ jobs:
       - name: Run job
         run: |
           mkdir -p build && cd build
-          cmake -GNinja -DICB=ON -DEXAMPLES=ON -DMPI=ON ..
+          echo "::group::Configure"
+          if [[ ${{ matrix.int64 }} == ON ]]; then
+            _blas_lib_flag="-DBLAS_LIBRARIES=openblas_64"
+          fi
+          cmake \
+            -GNinja \
+            -DICB=ON \
+            -DEXAMPLES=ON \
+            -DMPI=${{ matrix.mpi }} \
+            -DINTERFACE64=${{ matrix.int64 }} \
+            ${_blas_lib_flag} \
+            ..
+          echo "::endgroup::"
+          echo "::group::Build"
           cmake --build . -v
+          echo "::endgroup::"
       - name: Run tests
         run: |
-          export PATH="/c/Program Files/Microsoft MPI/Bin":$PATH # add mpiexec to msys2 path
+          if [[ ${{ matrix.mpi }} == ON ]]; then
+            export PATH="/c/Program Files/Microsoft MPI/Bin":$PATH # add mpiexec to msys2 path
+          fi
           cd build
           ctest --output-on-failure

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -279,6 +279,7 @@ jobs:
             ninja:p
             cc:p
             fc:p
+            eigen3:p
       - name: Install OpenBLAS and MS-MPI from MSYS2
         run: |
           if [[ ${{ matrix.int64 }} != ON ]]; then
@@ -312,6 +313,7 @@ jobs:
           cmake \
             -GNinja \
             -DICB=ON \
+            -DEIGEN=ON \
             -DEXAMPLES=ON \
             -DMPI=${{ matrix.mpi }} \
             -DINTERFACE64=${{ matrix.int64 }} \
@@ -326,5 +328,6 @@ jobs:
           if [[ ${{ matrix.mpi }} == ON ]]; then
             export PATH="/c/Program Files/Microsoft MPI/Bin":$PATH # add mpiexec to msys2 path
           fi
+          export PATH="${GITHUB_WORKSPACE}/build":$PATH # add libarpack.dll to msys2 path for tests that run in different directory
           cd build
           ctest --output-on-failure


### PR DESCRIPTION
## Pull request purpose

Add CI for CLANG64 environment of MSYS2.
Add runners for different configurations (MPI, INTERFACE64) on MinGW-w64.

This picks up on #415.

## Detailed changes proposed in this pull request

The [CLANG64 environment](https://www.msys2.org/docs/environments/) of MSYS2 uses a toolchain that it almost entirely based on LLVM tools. That includes compilers (incl. LLVM Flang), linker, and LLVM libc++ (instead of GNU's libstdc++). Most common build environments are based on GNU tools (apart from maybe macOS and MSVC on Windows).
It might be worth testing unusual build environments in CI to make sure they don't break unintentionally.

This PR adds runners for that build environment.
It also adds Eigen3 as an additional build dependency on MinGW to test it on that platform.
Additionally, it adds runners for the following configurations (to the UCRT64 and CLANG64 environments):
* MPI=ON/OFF
* INTERFACE64=ON/OFF

