### PR TITLE
CI: Install numpy from Homebrew on macOS

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -213,13 +213,9 @@ jobs:
           # https://github.com/actions/runner-images/issues/2322
           brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
           brew reinstall gcc # brings gfortran on path
-          brew install cmake eigen boost-python3 python3 
-          python3 -m venv ./venv
-          source ./venv/bin/activate
-          pip3 install numpy
+          brew install cmake eigen boost-python3 python3 numpy
       - name: Run job
         run: |
-          source ./venv/bin/activate
           mkdir -p build
           cd build
           export FC=gfortran

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -187,7 +187,7 @@ jobs:
           export CFLAGS="-Qunused-arguments"
           export CXX=mpic++ # Uses clang++.
           export CXXFLAGS="-Qunused-arguments"
-          LIBS="-framework Accelerate" cmake -DBLA_VENDOR=Generic -DEXAMPLES=ON -DICB=ON -DMPI=ON ..
+          cmake -DBLA_VENDOR=Apple -DEXAMPLES=ON -DICB=ON -DMPI=ON ..
           make all
           CTEST_OUTPUT_ON_FAILURE=1 make test
   macos_latest_cmake_python:
@@ -224,7 +224,7 @@ jobs:
           export CFLAGS="-Qunused-arguments"
           export CXX=clang++
           export CXXFLAGS="-Qunused-arguments"
-          LIBS="-framework Accelerate" cmake -DBLA_VENDOR=Generic -DEXAMPLES=ON -DICB=ON -DPYTHON3=ON ..
+          cmake -DBLA_VENDOR=Apple -DEXAMPLES=ON -DICB=ON -DPYTHON3=ON ..
           make all
           CTEST_OUTPUT_ON_FAILURE=1 make test
   macos_latest_autotools:


### PR DESCRIPTION
## Pull request purpose

Avoid version conflict with numpy on macOS runners.

## Detailed changes proposed in this pull request

Binary packages from different distributors could be built with different versions of dependencies. If these different versions are using an incompatible API or ABI this could lead to errors on build or execution time.

Try to install as many packages as possible from the same distributor (Homebrew in this case). I.e., no longer install numpy from pip while Python is installed from Homebrew.
This also simplifies the build rules for that job a bit. No virtual Python environment is needed.

Also, use non-conflicting configuration settings when it comes to the BLAS and LAPACK implementations on the macOS runners.
