### PR TITLE
Make ctests platform independent

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -330,7 +330,6 @@ jobs:
           if [[ ${{ matrix.mpi }} == ON ]]; then
             export PATH="/c/Program Files/Microsoft MPI/Bin":$PATH # add mpiexec to msys2 path
           fi
-          export PATH="${GITHUB_WORKSPACE}/build":$PATH # add libarpack.dll to msys2 path for tests that run in different directory
           cd build
           ctest
       - name: Re-run tests
@@ -340,7 +339,6 @@ jobs:
           if [[ ${{ matrix.mpi }} == ON ]]; then
             export PATH="/c/Program Files/Microsoft MPI/Bin":$PATH # add mpiexec to msys2 path
           fi
-          export PATH="${GITHUB_WORKSPACE}/build":$PATH # add libarpack.dll to msys2 path for tests that run in different directory
           cd build
           echo "::group::Re-run ctest"
           ctest --rerun-failed --output-on-failure || true

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,9 @@
 [ Kyle Guinn ]
  * Build PARPACK p[sd]lamch10.f with FFLAGS from ./configure instead of forcing -O0.  Build all of PARPACK with AM_FFLAGS.
 
+[ Markus Mützel ]
+ * CMake: Fix running CTests on Windows.
+
 arpack-ng - 3.9.1
 
 [ Fabien Péan ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,6 +711,11 @@ function(build_tests)
       configure_file(EXAMPLES/MATRIX_MARKET/issue215.mtx ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/issue215.mtx)
       configure_file(EXAMPLES/MATRIX_MARKET/issue215.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/issue215.sh)
       add_test(NAME issue215_tst WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${BASH_PROGRAM} issue215.sh)
+      if (WIN32 AND BUILD_SHARED_LIBS)
+        set_tests_properties(arpackmm_tst issue401_tst issue215_tst
+          PROPERTIES
+          ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:arpack>")
+      endif()
     endif()
 
     if (PYTHON3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,7 +626,23 @@ endif()
 ############################
 # TEST
 ############################
-function(build_tests)  
+
+function(add_test_with_rpath test_name)
+  # Add test which sets a current working directory that doesn't contain the
+  # libarpack library.
+  # Windows doesn't have a mechanism similar to RPATH on Linux or macOS.
+  # On Windows, if a test is running in a working directory that doesn't contain
+  # the ARPACK (and PARPACK) libraries, the path to these libraries has to be
+  # added to the PATH environment variable.
+  add_test(NAME ${test_name} ${ARGN})
+  if (WIN32 AND BUILD_SHARED_LIBS)
+    set_tests_properties(${test_name}
+      PROPERTIES
+      ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:arpack>")
+  endif()
+endfunction()
+
+function(build_tests)
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/TESTS)
 
   add_executable(dnsimp_test TESTS/dnsimp.f TESTS/mmio.f TESTS/debug.h)
@@ -704,18 +720,13 @@ function(build_tests)
       configure_file(EXAMPLES/MATRIX_MARKET/B.mtx  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/B.mtx)
       configure_file(EXAMPLES/MATRIX_MARKET/Bz.mtx ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Bz.mtx)
       configure_file(EXAMPLES/MATRIX_MARKET/arpackmm.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/arpackmm.sh)
-      add_test(NAME arpackmm_tst WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${BASH_PROGRAM} arpackmm.sh)
+      add_test_with_rpath(arpackmm_tst WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${BASH_PROGRAM} arpackmm.sh)
       configure_file(EXAMPLES/MATRIX_MARKET/issue401.mtx ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/issue401.mtx)
       configure_file(EXAMPLES/MATRIX_MARKET/issue401.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/issue401.sh)
-      add_test(NAME issue401_tst WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${BASH_PROGRAM} issue401.sh)
+      add_test_with_rpath(issue401_tst WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${BASH_PROGRAM} issue401.sh)
       configure_file(EXAMPLES/MATRIX_MARKET/issue215.mtx ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/issue215.mtx)
       configure_file(EXAMPLES/MATRIX_MARKET/issue215.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/issue215.sh)
-      add_test(NAME issue215_tst WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${BASH_PROGRAM} issue215.sh)
-      if (WIN32 AND BUILD_SHARED_LIBS)
-        set_tests_properties(arpackmm_tst issue401_tst issue215_tst
-          PROPERTIES
-          ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:arpack>")
-      endif()
+      add_test_with_rpath(issue215_tst WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${BASH_PROGRAM} issue215.sh)
     endif()
 
     if (PYTHON3)
@@ -800,7 +811,7 @@ endfunction(build_tests)
 
 if(TESTS)
     enable_testing()
-    set(CMAKE_CTEST_COMMAND ctest -V)   
+    set(CMAKE_CTEST_COMMAND ctest -V)
     build_tests()
 endif()
 


### PR DESCRIPTION
## Pull request purpose

Change configuration of some ctests on Windows so they work "out of the box".

## Detailed changes proposed in this pull request

Windows doesn't have a mechanism similar to rpaths. Instead, shared libraries are searched in the current working directory and in the directory with the executable followed by directories in the environment variable PATH.

Add the path to the shared libarpack library to PATH for ctests that run executables that are located in a different directory and that set the current working directory not to the directory with the libarpack.dll. Use a generator expression that should be working independent on the CMake generator.

Also remove the previously added work-around from the CI rules for MinGW that is no longer needed with that change.
