### PR TITLE
Calling correct functions according to proper types

### DIFF
--- a/PARPACK/SRC/BLACS/pcnaitr.f
+++ b/PARPACK/SRC/BLACS/pcnaitr.f
@@ -403,7 +403,7 @@ c
          if (msglvl .gt. 1) then
             call pivout (comm, logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call pcvout (comm, logfil, 1, [rnorm], ndigit,
+            call psvout (comm, logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
 c

--- a/PARPACK/SRC/BLACS/pznaitr.f
+++ b/PARPACK/SRC/BLACS/pznaitr.f
@@ -403,7 +403,7 @@ c
          if (msglvl .gt. 1) then
             call pivout (comm, logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call pzvout (comm, logfil, 1, [rnorm], ndigit,
+            call pdvout (comm, logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
 c

--- a/PARPACK/SRC/MPI/pcnaitr.f
+++ b/PARPACK/SRC/MPI/pcnaitr.f
@@ -406,7 +406,7 @@ c
          if (msglvl .gt. 1) then
             call pivout (comm, logfil, 1, [j], ndigit,
      &                  '_naitr: generating Arnoldi vector number')
-            call pdvout (comm, logfil, 1, [rnorm], ndigit,
+            call psvout (comm, logfil, 1, [rnorm], ndigit,
      &                  '_naitr: B-norm of the current residual is')
          end if
 c


### PR DESCRIPTION
Incorrect types would compile just fine but may result in errors when LTO is enabled.
The following is a typical one.

```text
parpack-src/pcnaitr.f:410: error: type of 'pdvout' does not match original declaration [-Werror=lto-type-mismatch]
  410 |      &                  '_naitr: B-norm of the current residual is')
      | 
parpack-src/pdvout.f:21: note: 'pdvout' was previously declared here
   21 |       SUBROUTINE PDVOUT( COMM , LOUT, N, SX, IDIGIT, IFMT )
      | 
parpack-src/pdvout.f:21: note: code may be misoptimized unless '-fno-strict-aliasing' is used
```