### PR TITLE
Fix "Warning: Obsolescent feature: Old-style character length at (1)", found in /UTIL

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -242,7 +242,7 @@ jobs:
       - name: Install brew dependencies
         run: |
           brew reinstall gcc # brings gfortran on path
-          brew install autoconf automake libtool pkg-config mpich eigen
+          brew install autoconf automake libtool pkgconfig open-mpi eigen
       - name: Run job
         run: |
           ./bootstrap

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Install brew dependencies
         run: |
           brew reinstall gcc # brings gfortran on path
-          brew install cmake mpich eigen
+          brew install cmake open-mpi eigen
       - name: Run job
         run: |
           mkdir -p build

--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,7 @@ arpack-ng - next
 
 [ Evan Biederstedt ]
 * Fix warnings for "Warning: Obsolescent feature: Old-style character length at (1)", compiled with `gfortran-16  -fpic  -g -O2 -Wall -pedantic -mtune=native`
-* Changed github workflows for Mac OS to use 'brew install open-mpi', as `mpich` fails. 
+* Changed GitHub CI workflows for Mac OS to use 'brew install open-mpi', as `mpich` fails. 
 
 [ Theodore Chang ]
  * CMake: Improve dependency linking, bump up minimum C++ standard version.

--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,10 @@
 arpack-ng - next
 
 [ Evan Biederstedt ]
-* Fix warnings for "Warning: Obsolescent feature: Old-style character length at (1)", compiled with `gfortran-16  -fpic  -g -O2 -Wall -pedantic -mtune=native`
+* Fix warnings for "Warning: Obsolescent feature: Old-style character length at (1)" based 
+on F77 syntax, compiled with `gfortran-16  -fpic  -g -O2 -Wall -pedantic -mtune=native`
 * Changed github workflows for Mac OS to use 'brew install open-mpi', as `mpich` fails. 
+
 
 [ Theodore Chang ]
  * CMake: Improve dependency linking, bump up minimum C++ standard version.

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ arpack-ng - next
 
 [ Evan Biederstedt ]
 * Fix warnings for "Warning: Obsolescent feature: Old-style character length at (1)", compiled with `gfortran-16  -fpic  -g -O2 -Wall -pedantic -mtune=native`
+* Changed github workflows for Mac OS to use 'brew install open-mpi', as `mpich` fails. 
 
 [ Theodore Chang ]
  * CMake: Improve dependency linking, bump up minimum C++ standard version.

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 arpack-ng - next
 
+[ Evan Biederstedt ]
+* Fix warnings for "Warning: Obsolescent feature: Old-style character length at (1)", compiled with `gfortran-16  -fpic  -g -O2 -Wall -pedantic -mtune=native`
+
 [ Theodore Chang ]
  * CMake: Improve dependency linking, bump up minimum C++ standard version.
 

--- a/PARPACK/UTIL/BLACS/pdmout.f
+++ b/PARPACK/UTIL/BLACS/pdmout.f
@@ -34,7 +34,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LDA, LOUT, M, N
 *     ..
 *     .. Array Arguments ..

--- a/PARPACK/UTIL/BLACS/pdvout.f
+++ b/PARPACK/UTIL/BLACS/pdvout.f
@@ -31,7 +31,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LOUT, N
 *     ..
 *     .. Array Arguments ..

--- a/PARPACK/UTIL/BLACS/psmout.f
+++ b/PARPACK/UTIL/BLACS/psmout.f
@@ -34,7 +34,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LDA, LOUT, M, N
 *     ..
 *     .. Array Arguments ..

--- a/PARPACK/UTIL/BLACS/psvout.f
+++ b/PARPACK/UTIL/BLACS/psvout.f
@@ -31,7 +31,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LOUT, N
 *     ..
 *     .. Array Arguments ..

--- a/PARPACK/UTIL/MPI/pdmout.f
+++ b/PARPACK/UTIL/MPI/pdmout.f
@@ -33,7 +33,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LDA, LOUT, M, N
 *     ..
 *     .. Array Arguments ..

--- a/PARPACK/UTIL/MPI/pdvout.f
+++ b/PARPACK/UTIL/MPI/pdvout.f
@@ -30,7 +30,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LOUT, N
 *     ..
 *     .. Array Arguments ..

--- a/PARPACK/UTIL/MPI/psmout.f
+++ b/PARPACK/UTIL/MPI/psmout.f
@@ -33,7 +33,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LDA, LOUT, M, N
 *     ..
 *     .. Array Arguments ..

--- a/PARPACK/UTIL/MPI/psvout.f
+++ b/PARPACK/UTIL/MPI/psvout.f
@@ -30,7 +30,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LOUT, N
 *     ..
 *     .. Array Arguments ..

--- a/TESTS/mmio.f
+++ b/TESTS/mmio.f
@@ -641,7 +641,7 @@ c
       integer indx(*)
       integer jndx(*)
       integer i, rows, cols, nnz, nnzreq, ounit
-      character*(*)rep,field,symm
+      character  rep*(*),field*(*),symm*(*)
 c
 c Test input qualifiers:
 c
@@ -753,7 +753,7 @@ c Convert uppercase letters to lowercase letters in string with
 c starting position pos and length len.
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       integer pos, len
-      character*(*) string
+      character string*(*)
 
       character     lcase*26, ucase*26
       save lcase,ucase
@@ -780,8 +780,8 @@ c
 c 30-Oct-96   Bug fix: fixed non-ansi zero stringlength
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       integer slen, start, next, begin, space, wlen
-      character*(*) word
-      character*(*) string
+      character  word*(*)
+      character  string*(*)
 
       begin = start
       do 5 i=start,slen
@@ -809,7 +809,7 @@ c     Countwd counts the number of words in string starting
 c     at position start.  On return, count is the number of words.
 c 30-Oct-96   Routine added
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-      character*(*) string
+      character string*(*)
       integer slen, start, next, wordlength, count
       character tmp2*2
 

--- a/UTIL/dmout.f
+++ b/UTIL/dmout.f
@@ -24,7 +24,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LDA, LOUT, M, N
 *     ..
 *     .. Array Arguments ..

--- a/UTIL/dvout.f
+++ b/UTIL/dvout.f
@@ -21,7 +21,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LOUT, N
 *     ..
 *     .. Array Arguments ..


### PR DESCRIPTION
## Pull request purpose

I think this PR is very similar to this: https://github.com/opencollab/arpack-ng/pull/473

This code is included in R packages. CRAN (the R package centralized repository) compiles the Fortran code with `gfortran-16  -fpic  -g -O2 -Wall -pedantic -mtune=native`, which was leading to the warnings

```
"Warning: Obsolescent feature: Old-style character length at (1)"
```

## Detailed changes proposed in this pull request

Very small semantic change to fix warnings


