### PR TITLE
PARPACK: Initialize machine dependent constants only once in `PDNAITR`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ arpack-ng - next
 [ Markus Mützel ]
  * CMake: Fix running CTests on Windows.
  * Use GNU Fortran ABI in CI tests on macOS.
+ * Initialize machine dependent constants only once in `PDNAITR`.
 
 [ Szabolcs Horvát ]
  * fix obsolescent character length warnings

--- a/PARPACK/SRC/MPI/pdnaitr.f
+++ b/PARPACK/SRC/MPI/pdnaitr.f
@@ -331,7 +331,7 @@ c
          call dlabad( unfl, ovfl )
          ulp = pdlamch10( comm, 'precision' )
          smlnum = unfl*( n / ulp )
-         first = .false.
+         aitr_first = .false.
       end if
 c
       if (ido .eq. 0) then


### PR DESCRIPTION
## Pull request purpose

The current implementation checks the value of the variable `aitr_first` but sets `first`.

## Detailed changes proposed in this pull request

Change that to set `aitr_first` to false after the initialization has run.

This also brings that part of the implementation of `PDNAITR` in line with the corresponding logic that is used in the implementation of the other `P?NAITR`.

