### PR TITLE
CI: Use VecLibFort as shim library for Apple Accelerate/VecLib on macOS.

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -176,18 +176,21 @@ jobs:
       - name: Install brew dependencies
         run: |
           brew reinstall gcc # brings gfortran on path
-          brew install cmake open-mpi eigen
+          brew install cmake open-mpi eigen veclibfort
       - name: Run job
         run: |
           mkdir -p build
           cd build
           export FC=mpif90 # Uses gfortran.
-          export FFLAGS="-ff2c -fno-second-underscore"
           export CC=mpicc # Uses clang.
           export CFLAGS="-Qunused-arguments"
           export CXX=mpic++ # Uses clang++.
           export CXXFLAGS="-Qunused-arguments"
-          cmake -DBLA_VENDOR=Apple -DEXAMPLES=ON -DICB=ON -DEIGEN=ON -DMPI=ON ..
+          export VECLIBFORT_PREFIX=$(brew --prefix veclibfort)
+          cmake \
+            -DBLAS_LIBRARIES="${VECLIBFORT_PREFIX}/lib/libvecLibFort.dylib" \
+            -DLAPACK_LIBRARIES="${VECLIBFORT_PREFIX}/lib/libvecLibFort.dylib" \
+            -DEXAMPLES=ON -DICB=ON -DEIGEN=ON -DMPI=ON ..
           make all
           CTEST_OUTPUT_ON_FAILURE=1 make test
   macos_latest_cmake_python:
@@ -213,18 +216,21 @@ jobs:
           # https://github.com/actions/runner-images/issues/2322
           brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
           brew reinstall gcc # brings gfortran on path
-          brew install cmake eigen boost-python3 python3 numpy
+          brew install cmake eigen boost-python3 python3 numpy veclibfort
       - name: Run job
         run: |
           mkdir -p build
           cd build
           export FC=gfortran
-          export FFLAGS="-ff2c -fno-second-underscore"
           export CC=clang
           export CFLAGS="-Qunused-arguments"
           export CXX=clang++
           export CXXFLAGS="-Qunused-arguments"
-          cmake -DBLA_VENDOR=Apple -DEXAMPLES=ON -DICB=ON -DEIGEN=ON -DPYTHON3=ON ..
+          export VECLIBFORT_PREFIX=$(brew --prefix veclibfort)
+          cmake \
+            -DBLAS_LIBRARIES="${VECLIBFORT_PREFIX}/lib/libvecLibFort.dylib" \
+            -DLAPACK_LIBRARIES="${VECLIBFORT_PREFIX}/lib/libvecLibFort.dylib" \
+            -DEXAMPLES=ON -DICB=ON -DEIGEN=ON -DPYTHON3=ON ..
           make all
           CTEST_OUTPUT_ON_FAILURE=1 make test
   macos_latest_autotools:
@@ -242,11 +248,13 @@ jobs:
       - name: Install brew dependencies
         run: |
           brew reinstall gcc # brings gfortran on path
-          brew install autoconf automake libtool pkgconfig open-mpi eigen
+          brew install autoconf automake libtool pkgconfig open-mpi eigen veclibfort
       - name: Run job
         run: |
           ./bootstrap
-          LIBS="-framework Accelerate" FFLAGS="-ff2c -fno-second-underscore" FCFLAGS="-ff2c -fno-second-underscore" \
+          export VECLIBFORT_PREFIX=$(brew --prefix veclibfort)
+          BLAS_LIBS="-L${VECLIBFORT_PREFIX}/lib -lvecLibFort" \
+          LAPACK_LIBS="-L${VECLIBFORT_PREFIX}/lib -lvecLibFort" \
             ./configure --enable-icb --enable-eigen --enable-mpi
           make all
           make check

--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ arpack-ng - next
 
 [ Markus Mützel ]
  * CMake: Fix running CTests on Windows.
+ * Use GNU Fortran ABI in CI tests on macOS.
 
 [ Szabolcs Horvát ]
  * fix obsolescent character length warnings


### PR DESCRIPTION
## Pull request purpose

Currently, the CI rules are building ARPACK using the old `f2c` Fortran ABI on macOS. However, all packages of applications written in Fortran that are distributed by Homebrew are using the default GNU Fortran ABI. Testing the package with the ABI expected by most macOS users would probably be better than what is currently done in the CI setup.

## Detailed changes proposed in this pull request

Instead of building a version of ARPACK using that old, non-default `f2c` Fortran ABI, use a library that "translates" from the default GNU Fortran ABI to the old `f2c` ABI used by Apple Accelerate/VecLib.
