### PR TITLE
CI: Use dependabot to periodically check for updated actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
## Pull request purpose

Currently, a warning like the following is emitted for each job in the CI:
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v2. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Detailed changes proposed in this pull request

Let dependabot check for updates to avoid the chore of manually updating the versions of GitHub actions every time the Node.js version on the runner images is updated.


You might need to enable dependabot for this repository if it isn't enabled yet before it can create PRs. See: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-security-updates