### PR TITLE
Do not install CMake config files when building with Makefile rules

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@ arpack-ng - next
  * CMake: Fix running CTests on Windows.
  * Use GNU Fortran ABI in CI tests on macOS.
  * Initialize machine dependent constants only once in `PDNAITR`.
+ * [BUG FIX] Do not install (incomplete) CMake config files when building with Makefile rules.
 
 [ Szabolcs Horvát ]
  * fix obsolescent character length warnings

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,3 @@ endif
 
 EXTRA_DIST = README.md PARPACK_CHANGES CHANGES DOCUMENTS VISUAL_STUDIO \
 detect_arpack_bug.m4 CMakeLists.txt
-
-cmakedir = $(libdir)/cmake/arpack-ng
-cmake_DATA = cmake/arpackng-config-version.cmake  \
-  cmake/arpackng-config.cmake

--- a/configure.ac
+++ b/configure.ac
@@ -357,8 +357,6 @@ AC_CONFIG_FILES([tstAutotoolsInstall.sh], [chmod +x tstAutotoolsInstall.sh], [ab
 AC_CONFIG_FILES([
 	arpackdef.h
 	arpackicb.h
-	cmake/arpackng-config-version.cmake
-	cmake/arpackng-config.cmake
 	Makefile
 	ICB/Makefile
 	UTIL/Makefile


### PR DESCRIPTION
## Pull request purpose

The CMake config files contain the following instruction:
```
 include("${CMAKE_CURRENT_LIST_DIR}/arpackngTargets.cmake")
```

The file `arpackngTargets.cmake` is generated by CMake. It is not generated by the Makefile rules (nor by the `configure` script).

That means that trying to use the CMake config files in downstream CMake projects leads to a fatal error like the following:
```
CMake Error at /usr/lib/x86_64-linux-gnu/cmake/arpack-ng/arpackng-config.cmake:35 (include):
  include could not find requested file:
```

CMake does not support catching fatal errors and continuing execution. That means that the configuration for downstream projects bails at that point even if ARPACK-ng is actually correctly installed (apart from the broken CMake config files).

On the other hand, if no CMake config files are installed at all, CMake determines that gracefully in downstream projects. If that should happen, these projects can fall back to alternative ways to locating ARPACK-ng (e.g., using the pkg-config files or looking at default locations).

## Detailed changes proposed in this pull request

This reverts #438 to avoid this error.
